### PR TITLE
Cop transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@
 
 # rspec failure tracking
 .rspec_status
-
-# RubyMine files
-/.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# RubyMine files
+/.idea/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,18 @@
+AllCops:
+  DisplayCopNames: true
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+  - "spec/**/*.rb"
+
+Metrics/MethodLength:
+  Enabled: true
+  CountComments: false
+  Max: 25
+
 Metrics/LineLength:
   Max: 120
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Exclude:
+  - "*.gemspec"
   - "spec/**/*.rb"
 
 Metrics/MethodLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ezcater_rubocop
 
 # v0.49.0 (unreleased)
-- Initial release
-- [RequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/9adbce126ba971b48a9944ef97d2ed6330342632/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) Cop
-- [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) Cop
-- [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) Cop
+- Initial release.
+- Add `Ezcater/RequireFeatureFlagMock` cop.
+- Add `Ezcater/RspecDotNotSelfDot` cop.
+- Add `Ezcater/StyleDig` cop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 # v0.49.0 (unreleased)
 - Initial release
 - [RequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/9adbce126ba971b48a9944ef97d2ed6330342632/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) Cop
+- [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) Cop
+- [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) Cop

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ the latest compatible version each time that the MAJOR.MINOR version of `rubocop
 is updated.
 
 ## Custom Cops
+1. [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) - Enforce ".<class method>" instead of "self.<class method>" for example group description.
 1. [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforces consumers to user custom `mock_feature_flag` helpers when writing tests that require turning `FeatureFlag` functionality on and off.
+1. [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) - Recommend `dig` for deeply nested access.
 
 ## Development
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,16 @@
+Ezcater/RspecDotNotSelfDot:
+  Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
+  Enabled: true
+  Include:
+    - '**/*_spec.rb'
+
+Ezcater/RspecRequireFeatureFlagMock:
+  Description: 'Enforce use of `mock_feature_flag` helpers instead of mocking `FeatureFlag.is_active?` directly.'
+  Enabled: true
+  Include:
+    - '**/*_spec.rb'
+
+Ezcater/StyleDig:
+  Description: 'Recommend `dig` for deeply nested access.'
+  Enabled: true
+  AutoCorrect: false

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -1,7 +1,17 @@
 require "ezcater_rubocop/version"
 require "rubocop-rspec"
 
-module EzcaterRubocop
-  # cops
-  require 'rubocop/cop/ezcater/rspec_require_feature_flag_mock'
-end
+# Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+# bit of our configuration. Based on approach from rubocop-rspec:
+DEFAULT_FILES = File.expand_path("../../config/default.yml", __FILE__)
+
+path = File.absolute_path(DEFAULT_FILES)
+hash = RuboCop::ConfigLoader.send(:load_yaml_configuration, path)
+config = RuboCop::Config.new(hash, path)
+puts "configuration from #{DEFAULT_FILES}" if RuboCop::ConfigLoader.debug?
+config = RuboCop::ConfigLoader.merge_with_default(config, path)
+RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
+
+require "rubocop/cop/ezcater/rspec_require_feature_flag_mock"
+require "rubocop/cop/ezcater/rspec_dot_not_self_dot"
+require "rubocop/cop/ezcater/style_dig"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.49.0".freeze
+  VERSION = "0.49.0.rc0".freeze
 end

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Salsify
+      # Use ".<class method>" instead of "self.<class method>" in RSpec example
+      # group descriptions.
+      #
+      # @example
+      #
+      #   # good
+      #   describe ".does_stuff" do
+      #     ...
+      #   end
+      #
+      #   # bad
+      #   describe "self.does_stuff" do
+      #     ...
+      #   end
+      class RspecDotNotSelfDot < Cop
+
+        SELF_DOT_REGEXP = /["']self\./
+        MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'.freeze
+
+        def_node_matcher :example_group_match, <<-PATTERN
+          (send _ #{RuboCop::RSpec::Language::ExampleGroups::ALL.node_pattern_union} $_ ...)
+        PATTERN
+
+        def on_send(node)
+          example_group_match(node) do |doc|
+            add_offense(doc, :expression, MSG) if SELF_DOT_REGEXP =~ doc.source
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(Parser::Source::Range.new(node.source_range.source_buffer,
+                                                       node.source_range.begin_pos + 1,
+                                                       node.source_range.begin_pos + 5))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -18,7 +18,6 @@ module RuboCop
       #     ...
       #   end
       class RspecDotNotSelfDot < Cop
-
         SELF_DOT_REGEXP = /["']self\./
         MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'.freeze
 

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    module Salsify
+    module Ezcater
       # Use ".<class method>" instead of "self.<class method>" in RSpec example
       # group descriptions.
       #

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    module Salsify
+    module Ezcater
       # Use `dig` for deeply nested access.
       #
       # @example

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -1,0 +1,68 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Salsify
+      # Use `dig` for deeply nested access.
+      #
+      # @example
+      #
+      #   # good
+      #   my_hash.dig('foo', 'bar')
+      #   my_array.dig(0, 1)
+      #
+      #   # bad
+      #   my_hash['foo']['bar']
+      #   my_hash['foo'] && my_hash['foo']['bar']
+      #   my_array[0][1]
+
+      class StyleDig < Cop
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
+
+        MSG = 'Use `dig` for nested access.'.freeze
+
+        def_node_matcher :nested_access_match, <<-PATTERN
+          (send (send (send _receiver !:[]) :[] _) :[] _)
+        PATTERN
+
+        def on_send(node)
+          if nested_access_match(node) && !conditional_assignment?(node)
+            match_node = node
+            # walk to outermost access node
+            match_node = match_node.parent while access_node?(match_node.parent)
+            add_offense(match_node, :expression, MSG)
+          end
+        end
+
+        def autocorrect(node)
+          access_node = node
+          source_args = [access_node.method_args.first.source]
+          while access_node?(access_node.children.first)
+            access_node = access_node.children.first
+            source_args << access_node.method_args.first.source
+          end
+          root_node = access_node.children.first
+
+          lambda do |corrector|
+            range = Parser::Source::Range.new(node.source_range.source_buffer,
+                                              root_node.source_range.end_pos,
+                                              node.source_range.end_pos)
+            corrector.replace(range, ".dig(#{source_args.reverse.join(', ')})")
+          end
+        end
+
+        private
+
+        def conditional_assignment?(node)
+          node.parent && node.parent.or_asgn_type? && (node.parent.children.first == node)
+        end
+
+        def access_node?(node)
+          node && node.send_type? && node.method_name == :[]
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -21,19 +21,18 @@ module RuboCop
 
         minimum_target_ruby_version 2.3
 
-        MSG = 'Use `dig` for nested access.'.freeze
+        MSG = "Use `dig` for nested access.".freeze
 
         def_node_matcher :nested_access_match, <<-PATTERN
           (send (send (send _receiver !:[]) :[] _) :[] _)
         PATTERN
 
         def on_send(node)
-          if nested_access_match(node) && !conditional_assignment?(node)
-            match_node = node
-            # walk to outermost access node
-            match_node = match_node.parent while access_node?(match_node.parent)
-            add_offense(match_node, :expression, MSG)
-          end
+          return unless nested_access_match(node) && !conditional_assignment?(node)
+          match_node = node
+          # walk to outermost access node
+          match_node = match_node.parent while access_node?(match_node.parent)
+          add_offense(match_node, :expression, MSG)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/rspec/language/each_selector.rb
+++ b/lib/rubocop/rspec/language/each_selector.rb
@@ -1,0 +1,13 @@
+# Monkey-patch SelectorSet to allow enumeration of selectors.
+
+module RuboCop
+  module RSpec
+    module Language
+      class SelectorSet
+        def each(&blk)
+          selectors.each(&blk)
+        end
+      end
+    end
+  end
+end

--- a/spec/ezcater_rubocop_spec.rb
+++ b/spec/ezcater_rubocop_spec.rb
@@ -1,5 +1,0 @@
-RSpec.describe EzcaterRubocop do
-  it "has a version number" do
-    expect(EzcaterRubocop::VERSION).not_to be nil
-  end
-end

--- a/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
@@ -1,0 +1,40 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::RspecDotNotSelfDot, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:msgs) { [described_class::MSG] }
+
+  RuboCop::RSpec::Language::ExampleGroups::ALL.each do |name|
+    it "corrects #{name} with `self.class_method`" do
+      source = "#{name} \"self.class_method\" do\nend"
+      inspect_source(cop, source)
+      expect(cop.highlights).to eq(['"self.class_method"'])
+      expect(cop.messages).to eq(msgs)
+      expect(autocorrect_source(cop, source)).to eq(source.sub('self.', '.'))
+    end
+
+    it "corrects #{name} with `self.class_method` and metadata" do
+      source = "#{name} \"self.class_method\", foo: true do\nend"
+      inspect_source(cop, source)
+      expect(cop.highlights).to eq(['"self.class_method"'])
+      expect(cop.messages).to eq(msgs)
+      expect(autocorrect_source(cop, source)).to eq(source.sub('self.', '.'))
+    end
+
+    it "accepts #{name} with `.class_method`" do
+      source = "#{name} \".class_method\" do\nend"
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  RuboCop::RSpec::Language::Examples::ALL.each do |name|
+    it "accepts #{name} with `self.class_method`" do
+      source = "#{name} \"self.class_method\" do\nend"
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
@@ -1,7 +1,7 @@
 # encoding utf-8
 # frozen_string_literal: true
 
-describe RuboCop::Cop::Salsify::RspecDotNotSelfDot, :config do
+RSpec.describe RuboCop::Cop::Ezcater::RspecDotNotSelfDot, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:msgs) { [described_class::MSG] }

--- a/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Salsify::RspecDotNotSelfDot, :config do
       inspect_source(cop, source)
       expect(cop.highlights).to eq(['"self.class_method"'])
       expect(cop.messages).to eq(msgs)
-      expect(autocorrect_source(cop, source)).to eq(source.sub('self.', '.'))
+      expect(autocorrect_source(cop, source)).to eq(source.sub("self.", "."))
     end
 
     it "corrects #{name} with `self.class_method` and metadata" do
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Salsify::RspecDotNotSelfDot, :config do
       inspect_source(cop, source)
       expect(cop.highlights).to eq(['"self.class_method"'])
       expect(cop.messages).to eq(msgs)
-      expect(autocorrect_source(cop, source)).to eq(source.sub('self.', '.'))
+      expect(autocorrect_source(cop, source)).to eq(source.sub("self.", "."))
     end
 
     it "accepts #{name} with `.class_method`" do

--- a/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireFeatureFlagMock, :config do
 
   it "accepts usage of the mock_feature_flag helper with options" do
     inspect_source(cop, [
-      "user = create(:user)",
-      "mock_feature_flag(\"MyFeatureFlag\", { user: user }, true)"
-    ])
+                     "user = create(:user)",
+                     "mock_feature_flag(\"MyFeatureFlag\", { user: user }, true)"
+                   ])
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -7,62 +7,62 @@ describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
   subject(:cop) { described_class.new(config) }
 
   it "accepts non-nested access" do
-    source = 'ary[0]'
+    source = "ary[0]"
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
 
   it "corrects nested access" do
-    source = 'hash[one][two]'
+    source = "hash[one][two]"
     inspect_source(cop, source)
     expect(cop.highlights).to eq([source])
     expect(cop.messages).to eq(msgs)
-    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two)')
+    expect(autocorrect_source(cop, source)).to eq("hash.dig(one, two)")
   end
 
   it "corrects triple-nested access" do
-    source = 'hash[one][two][three]'
+    source = "hash[one][two][three]"
     inspect_source(cop, source)
     expect(cop.highlights).to eq([source])
     expect(cop.messages).to eq(msgs)
-    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two, three)')
+    expect(autocorrect_source(cop, source)).to eq("hash.dig(one, two, three)")
   end
 
   it "corrects nested access after a method call" do
-    source = 'obj.hash[:one][:two]'
+    source = "obj.hash[:one][:two]"
     inspect_source(cop, source)
     expect(cop.highlights).to eq([source])
     expect(cop.messages).to eq(msgs)
-    expect(autocorrect_source(cop, source)).to eq('obj.hash.dig(:one, :two)')
+    expect(autocorrect_source(cop, source)).to eq("obj.hash.dig(:one, :two)")
   end
 
   it "corrects nested access for a method arg" do
-    source = 'call(array[0][1])'
+    source = "call(array[0][1])"
     inspect_source(cop, source)
-    expect(cop.highlights).to eq(['array[0][1]'])
+    expect(cop.highlights).to eq(["array[0][1]"])
     expect(cop.messages).to eq(msgs)
-    expect(autocorrect_source(cop, source)).to eq('call(array.dig(0, 1))')
+    expect(autocorrect_source(cop, source)).to eq("call(array.dig(0, 1))")
   end
 
   it "corrects when a method is called after nested access" do
-    source = 'hash[one][two].foo'
+    source = "hash[one][two].foo"
     inspect_source(cop, source)
-    expect(cop.highlights).to eq(['hash[one][two]'])
+    expect(cop.highlights).to eq(["hash[one][two]"])
     expect(cop.messages).to eq(msgs)
-    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two).foo')
+    expect(autocorrect_source(cop, source)).to eq("hash.dig(one, two).foo")
   end
 
   it "accepts nested access on conditional assignment" do
-    source = 'foo[bar][baz] ||= 1'
+    source = "foo[bar][baz] ||= 1"
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
 
   it "corrects nested access in the value for conditional assignment" do
-    source = 'blah ||= foo[bar][baz]'
+    source = "blah ||= foo[bar][baz]"
     inspect_source(cop, source)
-    expect(cop.highlights).to eq(['foo[bar][baz]'])
+    expect(cop.highlights).to eq(["foo[bar][baz]"])
     expect(cop.messages).to eq(msgs)
-    expect(autocorrect_source(cop, source)).to eq('blah ||= foo.dig(bar, baz)')
+    expect(autocorrect_source(cop, source)).to eq("blah ||= foo.dig(bar, baz)")
   end
 end

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -1,0 +1,68 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
+  let(:msgs) { [described_class::MSG] }
+
+  subject(:cop) { described_class.new(config) }
+
+  it "accepts non-nested access" do
+    source = 'ary[0]'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access" do
+    source = 'hash[one][two]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two)')
+  end
+
+  it "corrects triple-nested access" do
+    source = 'hash[one][two][three]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two, three)')
+  end
+
+  it "corrects nested access after a method call" do
+    source = 'obj.hash[:one][:two]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq([source])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('obj.hash.dig(:one, :two)')
+  end
+
+  it "corrects nested access for a method arg" do
+    source = 'call(array[0][1])'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq(['array[0][1]'])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('call(array.dig(0, 1))')
+  end
+
+  it "corrects when a method is called after nested access" do
+    source = 'hash[one][two].foo'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq(['hash[one][two]'])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('hash.dig(one, two).foo')
+  end
+
+  it "accepts nested access on conditional assignment" do
+    source = 'foo[bar][baz] ||= 1'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access in the value for conditional assignment" do
+    source = 'blah ||= foo[bar][baz]'
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq(['foo[bar][baz]'])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq('blah ||= foo.dig(bar, baz)')
+  end
+end

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -1,7 +1,7 @@
 # encoding utf-8
 # frozen_string_literal: true
 
-describe RuboCop::Cop::Salsify::StyleDig, :config, :ruby23 do
+RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config, :ruby23 do
   let(:msgs) { [described_class::MSG] }
 
   subject(:cop) { described_class.new(config) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 require "ezcater_rubocop"
 require "rspec"
 require "rubocop/rspec/support"
+require "rubocop/rspec/language/each_selector"
 require "pry"
 
 RSpec.configure do |config|


### PR DESCRIPTION
This change copies the `StyleDig` and `RspecDotNotSelfDot` cops from salsify_rubocop.

The code is copied in a separate commit, rubocop offenses based on this repo's config are corrected in a separate commit, and any other edits required to get the code working in this repo are a further commit.

There is a another commit to add default configuration, REAME, changelog, etc.

And a final round of fixing rubocop offenses.

I've manually tested this code with ez-rails and it seems to be working as expected. I'd like to release a 0.49.0.rc0 release candidate once this PR is merged, and then test that with ez-rails in CI. After that I'll make an official 0.49.0 release.

This project should be setup in Circle. My plan is to handle that in a separate PR.