### PR TITLE
Fix constant targeting for Browser mock cop

### DIFF
--- a/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
@@ -25,7 +25,7 @@ module RuboCop
         PATTERN
 
         def on_const(node)
-          return unless browser_const?(node)
+          return unless browser_const?(node) && node.descendants.empty?
 
           # Walk to send node where method = :allow
           match_node = node

--- a/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
@@ -17,6 +17,12 @@ RSpec.shared_examples_for "a browser class that should be mocked" do |klass|
       expect(cop.messages).to eq([error_message])
       expect(cop.highlights).to eq([source])
     end
+
+    it "accepts usage of #{klass} when nested beneath another constant" do
+      source = "allow(SomeOtherClass::#{klass}).to receive(:new).with(\"My User Agent\", language: \"en=US,en\")"
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
   end
 end
 


### PR DESCRIPTION
Fixing the Browser cop to ignore compound constants that happen to end in `Browser`/`EzBrowser`