### PR TITLE
Fix StyleDig to allow nested access in assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+# v0.49.2
+- Do no apply `Ezcater/StyleDig` to assignments to with nested access.
+
 # v0.49.1
 - Add `Ezcater/RspecRequireBrowserMock` cop.
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.49.1".freeze
+  VERSION = "0.49.2".freeze
 end

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -28,7 +28,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless nested_access_match(node) && !conditional_assignment?(node)
+          return unless nested_access_match(node) && !assignment?(node)
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)
@@ -54,8 +54,8 @@ module RuboCop
 
         private
 
-        def conditional_assignment?(node)
-          node.parent && node.parent.or_asgn_type? && (node.parent.children.first == node)
+        def assignment?(node)
+          node.parent&.assignment? && (node.parent.children.first == node)
         end
 
         def access_node?(node)

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -65,4 +65,24 @@ RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config, :ruby23 do
     expect(cop.messages).to eq(msgs)
     expect(autocorrect_source(cop, source)).to eq("blah ||= foo.dig(bar, baz)")
   end
+
+  it "accepts nested access for increment" do
+    source = "foo[bar][baz] += 1"
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "accepts nested access for assignment" do
+    source = "foo[bar][baz] = 0"
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access with append" do
+    source = "foo[bar][baz] << 1"
+    inspect_source(cop, source)
+    expect(cop.highlights).to eq(["foo[bar][baz]"])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq("foo.dig(bar, baz) << 1")
+  end
 end


### PR DESCRIPTION
This PR is against the `v0.49-release`.

Previously this cop only allowed for `||=`, probably because that is what I encountered in the code base where this was used originally.

There is a separate PR for the master/v0.50 version.