### PR TITLE
Fix StyleDig to allow nested access in assignments (v0.50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v0.50.0 (unreleased)
 - Update to rubocop v0.50.0 and rubocop-rspec v1.18.0.
+- Do not apply `Ezcater/StyleDig` to assignments with nested access.
 
 # v0.49.1
 - Add `Ezcater/RspecRequireBrowserMock` cop.

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -26,7 +26,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless nested_access_match(node) && !conditional_assignment?(node)
+          return unless nested_access_match(node) && !assignment?(node)
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)
@@ -52,8 +52,8 @@ module RuboCop
 
         private
 
-        def conditional_assignment?(node)
-          node.parent&.or_asgn_type? && (node.parent.children.first == node)
+        def assignment?(node)
+          node.parent&.assignment? && (node.parent.children.first == node)
         end
 
         def access_node?(node)

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -65,4 +65,24 @@ RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config, :ruby23 do
     expect(cop.messages).to eq(msgs)
     expect(autocorrect_source(source)).to eq("blah ||= foo.dig(bar, baz)")
   end
+
+  it "accepts nested access for increment" do
+    source = "foo[bar][baz] += 1"
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "accepts nested access for assignment" do
+    source = "foo[bar][baz] = 0"
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access with append" do
+    source = "foo[bar][baz] << 1"
+    inspect_source(source)
+    expect(cop.highlights).to eq(["foo[bar][baz]"])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(source)).to eq("foo.dig(bar, baz) << 1")
+  end
 end


### PR DESCRIPTION
This PR is against the `rubocop-v0.50.0` branch that is intended to be merged to master.