### PR TITLE
Add shared configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,27 +1,6 @@
-AllCops:
-  DisplayCopNames: true
+inherit_from:
+  - conf/rubocop.yml
 
-Metrics/AbcSize:
+# Disable because aggregate_failures is configured globally
+RSpec/MultipleExpectations:
   Enabled: false
-
-Metrics/BlockLength:
-  Exclude:
-  - "*.gemspec"
-  - "spec/**/*.rb"
-
-Metrics/MethodLength:
-  Enabled: true
-  CountComments: false
-  Max: 25
-
-Metrics/LineLength:
-  Max: 120
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # ezcater_rubocop
 
-# v0.50.0
+## v0.50.1
+- Add shared configuration.
+
+## v0.50.0
 - Update to rubocop v0.50.0 and rubocop-rspec v1.18.0.
 - Do not apply `Ezcater/StyleDig` to assignments with nested access.
 
-# v0.49.1
+## v0.49.1
 - Add `Ezcater/RspecRequireBrowserMock` cop.
 
-# v0.49.0
+## v0.49.0
 - Initial release.
 - Add `Ezcater/RspecRequireFeatureFlagMock` cop.
 - Add `Ezcater/RspecDotNotSelfDot` cop.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 Or to your gem's gemspec file:
 
 ```ruby
-spec.add_development_dependency "salsify_rubocop"
+spec.add_development_dependency "ezcater_rubocop"
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ezcater_rubocop
 
-ezCater custom cops, and eventually shared rubocop configuration.
+ezCater custom cops and shared RuboCop configuration.
 
 [RuboCop](https://github.com/bbatsov/rubocop) is a static code analyzer that
 can enforce style conventions as well as identify common problems.
@@ -15,6 +15,12 @@ group :development do
 end
 ```
 
+Or to your gem's gemspec file:
+
+```ruby
+spec.add_development_dependency "salsify_rubocop"
+```
+
 And then execute:
 
     $ bundle install
@@ -22,6 +28,24 @@ And then execute:
 Or install it yourself as:
 
     $ gem install ezcater_rubocop
+
+## Configuration
+
+To use one of the shared RuboCop configurations from this gem, you must define a
+.rubocop.yml file in your project:
+
+```yaml
+inherit_gem:
+  ezcater_rubocop: conf/rubocop_rails.yml
+```
+
+Further customization of RuboCop for your local project may be added to this file.
+
+### Available Configurations
+
+- **rubocop**: Assumes RSpec is used and requires [rubocop-rspec](https://github.com/backus/rubocop-rspec).
+  This configuration should be used for gems.
+- **rubocop_rails**: For Rails projects, this inherits from the **rubocop** configuration.
 
 ## Usage
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -1,0 +1,48 @@
+require: ezcater_rubocop
+
+AllCops:
+  DisplayCopNames: true
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+  - "*.gemspec"
+  - "spec/**/*.rb"
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Enabled: true
+  CountComments: false
+  Max: 25
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Rails:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+# This cop does not yet support a style to prevent underscores
+Style/NumericLiterals:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -1,0 +1,14 @@
+inherit_from:
+  - ../conf/rubocop.yml
+
+AllCops:
+  TargetRailsVersion: 5.1
+
+Rails:
+  Enabled: true
+
+Rails/RelativeDateConstant:
+  # Auto-correct is broken for this cops in some cases. It replaces the
+  # constant but does not update references to it.
+  AutoCorrect: false
+

--- a/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireBrowserMock, :config do
     expect(cop.offenses).to be_empty
   end
 
-  it "accepts usage of the mock_ezcater_app helper with options" do
+  it "accepts usage of the mock_chrome_browser helper with options" do
     inspect_source(
       "browser = mock_chrome_browser(device: \"iPhone\", version: \"1.2\", language: \"en=US,en\")"
     )

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config, :ruby23 do
-  let(:msgs) { [described_class::MSG] }
-
   subject(:cop) { described_class.new(config) }
+
+  let(:msgs) { [described_class::MSG] }
 
   it "accepts non-nested access" do
     source = "ary[0]"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
 end


### PR DESCRIPTION
This adds some pretty minimal rubocop configuration that can be shared via this gem.

My thinking was to start small and we'll evolve this configuration as we hit things that we dislike, or we re-evaluate cops as we work to cleanup ez-rails.

What went into this initial configuration?

- Copied what we already had in this gem and configuration from ezcater-delivery.
- Disabled the complexity gems as I've never seen them add much value -- but happy to discuss keeping them.
- Disabled the `Style/SingleLineBlockParams` which was also disabled in sem-tools.

There is also some additional cleanup here as rubocop-rspec was not actually being applied previously.