### PR TITLE
Do not apply dig to ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # ezcater_rubocop
 
+# v0.49.3
+- Do not apply `Ezcater/StyleDig` to access using a range.
+
 # v0.49.2
-- Do no apply `Ezcater/StyleDig` to assignments to with nested access.
+- Do not apply `Ezcater/StyleDig` to assignments to with nested access.
 
 # v0.49.1
 - Add `Ezcater/RspecRequireBrowserMock` cop.

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.49.2".freeze
+  VERSION = "0.49.3".freeze
 end

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -24,7 +24,7 @@ module RuboCop
         MSG = "Use `dig` for nested access.".freeze
 
         def_node_matcher :nested_access_match, <<-PATTERN
-          (send (send (send _receiver !:[]) :[] _) :[] _)
+          (send (send (send _receiver !:[]) :[] !{irange erange}) :[] !{irange erange})
         PATTERN
 
         def on_send(node)
@@ -59,7 +59,11 @@ module RuboCop
         end
 
         def access_node?(node)
-          node && node.send_type? && node.method_name == :[]
+          node && node.send_type? && node.method_name == :[] && !range?(node.method_args.first)
+        end
+
+        def range?(node)
+          node.irange_type? || node.erange_type?
         end
       end
     end

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -85,4 +85,30 @@ RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config, :ruby23 do
     expect(cop.messages).to eq(msgs)
     expect(autocorrect_source(cop, source)).to eq("foo.dig(bar, baz) << 1")
   end
+
+  it "accepts nested access that uses an inclusive range" do
+    source = "foo[bar][0..2]"
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "accepts nested access that uses an exclusive range" do
+    source = "foo[bar][0...2]"
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects nested access before the use of an inclusive range" do
+    source = "foo[bar][baz][0..2]"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq("foo.dig(bar, baz)[0..2]")
+  end
+
+  it "corrects nested access before the use of an exclusive range" do
+    source = "foo[bar][baz][0...2]"
+    inspect_source(cop, source)
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(cop, source)).to eq("foo.dig(bar, baz)[0...2]")
+  end
 end


### PR DESCRIPTION
Hit yet another edge case with this custom cop.

This change is against the `v0.49-release` branch.