### PR TITLE
Add Ezcater/PrivateAttr cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ezcater_rubocop
 
+## v0.50.2 (unreleased)
+- Add `Ezcater/PrivateAttr` custom cop.
+- Configure `RSpec/ExampleLength` with a `Max` value of 25.
+
 ## v0.50.1
 - Add shared configuration.
 - Do not apply `Ezcater/StyleDig` to access using a range.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ the latest compatible version each time that the MAJOR.MINOR version of `rubocop
 is updated.
 
 ## Custom Cops
+1. [PrivateAttr](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/private_attr.rb) - Require methods from the `private_attr` gem.
 1. [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) - Enforce ".<class method>" instead of "self.<class method>" for example group description.
 1. [RspecRequireBrowserMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb) - Enforce use of `mock_ezcater_app`, `mock_chrome_browser` & `mock_custom_browser` helpers instead of mocking `Browser` or `EzBrowser` directly.
 1. [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforce use of `mock_feature_flag` helper instead of mocking `FeatureFlag.is_active?` directly.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -31,6 +31,9 @@ Metrics/PerceivedComplexity:
 Rails:
   Enabled: false
 
+RSpec/ExampleLength:
+  Max: 25
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,7 @@
+Ezcater/PrivateAttr:
+  Description: 'Require methods from the private_attr gem'
+  Enabled: true
+
 Ezcater/RspecDotNotSelfDot:
   Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -12,6 +12,7 @@ puts "configuration from #{DEFAULT_FILES}" if RuboCop::ConfigLoader.debug?
 config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
+require "rubocop/cop/ezcater/private_attr"
 require "rubocop/cop/ezcater/rspec_require_browser_mock"
 require "rubocop/cop/ezcater/rspec_require_feature_flag_mock"
 require "rubocop/cop/ezcater/rspec_dot_not_self_dot"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.50.1".freeze
+  VERSION = "0.50.2".freeze
 end

--- a/lib/rubocop/cop/ezcater/private_attr.rb
+++ b/lib/rubocop/cop/ezcater/private_attr.rb
@@ -1,0 +1,104 @@
+module RuboCop
+  module Cop
+    module Ezcater
+      # This cop checks for the use of `attr_accessor`, `attr_reader`, `attr_writer`
+      # and `alias_method` after the access modifiers `private` and `protected`
+      # and requires the use of methods from the private_attr gem instead.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   class C
+      #     private
+      #
+      #     attr_accessor :foo
+      #     attr_reader :bar
+      #     attr_writer :baz
+      #     alias_method :foobar, foo
+      #   end
+      #
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   class C
+      #     private_attr_accessor :foo
+      #     private_attr_reader :bar
+      #     private_attr_writer :baz
+      #     private_alias_method :foobar, :foo
+      #
+      #     private
+      #
+      #     def shy
+      #       puts "hi"
+      #     end
+      #   end
+      class PrivateAttr < Cop
+        ATTR_METHODS = %i[attr_accessor
+                          attr_reader
+                          attr_writer].freeze
+
+        ACCESS_AFFECTED_METHODS = (ATTR_METHODS + %i[alias_method]).to_set.freeze
+
+        MSG = "Use `%s_%s` instead".freeze
+
+        def on_class(node)
+          check_node(node.children[2]) # class body
+        end
+
+        def on_module(node)
+          check_node(node.children[1]) # module body
+        end
+
+        private
+
+        def clear
+          @access_affected_calls = {}
+        end
+
+        def check_node(node)
+          return unless node&.begin_type?
+
+          clear
+          check_scope(node)
+
+          @access_affected_calls.each do |method_name, (send_node, visibility)|
+            add_offense(send_node, :expression,
+                        format_message(visibility, method_name))
+          end
+        end
+
+        def format_message(visibility, method_name)
+          format(MSG, visibility, method_name)
+        end
+
+        def check_scope(node, current_visibility = :public)
+          node.children.reduce(current_visibility) do |visibility, child|
+            check_child_scope(child, visibility)
+          end
+        end
+
+        def check_child_scope(node, current_visibility)
+          if node.send_type?
+            if node.access_modifier? && !node.method?(:module_function)
+              current_visibility = node.method_name
+            elsif ACCESS_AFFECTED_METHODS.include?(node.method_name)
+              add_access_affected_call(node, current_visibility) if current_visibility != :public
+            end
+
+          elsif node.kwbegin_type?
+            check_scope(node, current_visibility)
+          end
+
+          current_visibility
+        end
+
+        def add_access_affected_call(node, current_visibility)
+          @access_affected_calls[node.method_name] = [node, current_visibility]
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ezcater/private_attr.rb
+++ b/lib/rubocop/cop/ezcater/private_attr.rb
@@ -54,20 +54,10 @@ module RuboCop
 
         private
 
-        def clear
-          @access_affected_calls = {}
-        end
-
         def check_node(node)
           return unless node&.begin_type?
 
-          clear
           check_scope(node)
-
-          @access_affected_calls.each do |method_name, (send_node, visibility)|
-            add_offense(send_node, :expression,
-                        format_message(visibility, method_name))
-          end
         end
 
         def format_message(visibility, method_name)
@@ -84,19 +74,16 @@ module RuboCop
           if node.send_type?
             if node.access_modifier? && !node.method?(:module_function)
               current_visibility = node.method_name
-            elsif ACCESS_AFFECTED_METHODS.include?(node.method_name)
-              add_access_affected_call(node, current_visibility) if current_visibility != :public
+            elsif ACCESS_AFFECTED_METHODS.include?(node.method_name) && current_visibility != :public
+              add_offense(node,
+                          :expression,
+                          format_message(current_visibility, node.method_name))
             end
-
           elsif node.kwbegin_type?
             check_scope(node, current_visibility)
           end
 
           current_visibility
-        end
-
-        def add_access_affected_call(node, current_visibility)
-          @access_affected_calls[node.method_name] = [node, current_visibility]
         end
       end
     end

--- a/spec/rubocop/cop/ezcater/private_attr_spec.rb
+++ b/spec/rubocop/cop/ezcater/private_attr_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::PrivateAttr do
+  subject(:cop) { described_class.new }
+
+  %i[private protected].each do |access_modifier|
+    described_class::ATTR_METHODS.each do |method_name|
+      context "when `#{access_modifier}` is applied to `#{method_name}`" do
+        it "registers an offense" do
+          expect_offense(<<-RUBY.strip_indent)
+        class C
+          #{access_modifier}
+
+          #{method_name} :foo
+          #{'^' * (method_name.size + 5)} Use `#{access_modifier}_#{method_name}` instead
+        end
+          RUBY
+        end
+      end
+
+      context "when `#{access_modifier}` is applied to `#{method_name}` across multiple lines" do
+        it "registers an offense" do
+          expect_offense(<<-RUBY.strip_indent)
+        class C
+          #{access_modifier}
+
+          #{method_name} :foo,
+          #{'^' * (method_name.size + 6)} Use `#{access_modifier}_#{method_name}` instead
+                         :bar
+        end
+          RUBY
+        end
+      end
+
+      context "when `#{access_modifier}` is applied after `#{method_name}`" do
+        it "doesn't register an offense" do
+          expect_no_offenses(<<-RUBY.strip_indent)
+        class C
+          #{method_name} :foo
+
+          #{access_modifier}
+        end
+          RUBY
+        end
+      end
+
+      context "when `protected` is applied after `#{method_name}`" do
+        it "doesn't register an offense" do
+          expect_no_offenses(<<-RUBY.strip_indent)
+        class C
+          #{method_name} :foo
+
+          protected
+        end
+          RUBY
+        end
+      end
+    end
+
+    context "when `#{access_modifier}` is applied to `alias_method`" do
+      it "registers an offense" do
+        expect_offense(<<-RUBY.strip_indent)
+      class C
+        #{access_modifier}
+
+        alias_method :new_foo, :foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{access_modifier}_alias_method` instead
+      end
+        RUBY
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,4 +19,6 @@ RSpec.configure do |config|
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true
   end
+
+  config.include(RuboCop::RSpec::ExpectOffense)
 end


### PR DESCRIPTION
This change adds a new custom cop, `Ezcater/PrivateAttr`, that recommends the use of the methods provided by the [private_attr](https://github.com/jswanner/private_attr) gem. 

The implementation was based on the existing official `Lint/InaffectiveAccessModifier` cop: https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/ineffective_access_modifier.rb

The specs for the new cop use the newer `expect_offense`/`expect_no_offenses` syntax that the main repo is moving to.

This is something that we are trying out in newer applications, and we want something to remind people to use these methods from the gem.

Included with this change is a configuration update to raise the maximum allowed RSpec example size to 25, matching our method length limit.