### PR TITLE
Add circle_rubocop.rb script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ezcater_rubocop
 
-## v0.50.2 (unreleased)
+## v0.50.2
 - Add `Ezcater/PrivateAttr` custom cop.
 - Configure `RSpec/ExampleLength` with a `Max` value of 25.
 - Add `circle_rubocop.rb` script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.50.2 (unreleased)
 - Add `Ezcater/PrivateAttr` custom cop.
 - Configure `RSpec/ExampleLength` with a `Max` value of 25.
+- Add `circle_rubocop.rb` script.
 
 ## v0.50.1
 - Add shared configuration.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Run `rubocop` for an entire project:
 See the `rubocop` command-line for additional options including auto-generating
 configuration for existing offenses and auto-correction.
 
+### Circle Script
+
+This gem contains a script, `circle_rubocop.rb`, that can be used to run RuboCop in CI.
+
+The behavior of the script is that all files are checked on master or if the rubocop
+configuration has changed. On non-master branches, only the files added or changed on
+the branch are checked.
+
+For non-master branches, `[rubocop skip]` can be included in the commit message to skip
+running rubocop.
+
 ## Versioning
 
 This gem is versioned based on the MAJOR.MINOR version of `rubocop`. The first

--- a/bin/circle_rubocop.rb
+++ b/bin/circle_rubocop.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require "English"
+
+# This script is used to run Rubocop in CircleCI so that on branches only
+# the changed files are checked and on master all files are checked.
+#
+# Additionally if rubocop configuration is changed, all files are checked, and
+# if the commit description on a non-master branch includes [rubocop skip]
+# then rubocop is skipped.
+
+def run(command)
+  puts "Running: #{command}"
+  exit 1 unless system(command)
+end
+
+def rubocop_everything
+  run("bundle exec rubocop --parallel")
+end
+
+begin
+  if ENV["CIRCLE_BRANCH"] == "master"
+    rubocop_everything
+  else
+    git_commit_desc = `git log --format=%B -n 1 $CIRCLE_SHA1`
+    puts "Git commit: #{git_commit_desc}"
+    if git_commit_desc.match?(/\[rubocop skip\]/i)
+      puts "Skipping RuboCop"
+      exit 0
+    end
+
+    changed_files = `git diff --diff-filter=d --name-only origin/master...$CIRCLE_BRANCH`.split("\n").join(" ")
+    raise "Failed to identify changed files" unless $CHILD_STATUS.success?
+
+    if changed_files.strip.empty? || changed_files.include?(".rubocop")
+      rubocop_everything
+    else
+      run("bundle exec rubocop --force-exclusion #{changed_files}")
+    end
+  end
+rescue StandardError => ex
+  puts "Error: #{ex.message}"
+  rubocop_everything
+end

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -22,9 +22,20 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
+  excluded_files = %w[.circleci/config.yml
+                      .gitignore
+                      .rspec
+                      .rubocop.yml
+                      .ruby-gemset
+                      .ruby-version
+                      .travis.yml
+                      bin/console
+                      bin/setup
+                      Rakefile]
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
-  end
+  end - excluded_files
   spec.bindir = "bin"
   spec.executables << "circle_rubocop.rb"
   spec.require_paths = ["lib"]

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "bin"
+  spec.executables << "circle_rubocop.rb"
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.15"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.50.2".freeze
+  VERSION = "0.50.2.rc1".freeze
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.50.2.rc1".freeze
+  VERSION = "0.50.2".freeze
 end


### PR DESCRIPTION
This change adds the `circle_rubocop.rb` script to the gem so that it can be shared between applications.

I already cut a pre-release with the version number included here to test this with `ezcater-identity`: https://circleci.com/gh/ezcater/ezcater-identity/30

There are a couple of changes in flight for this gem, so they will likely be combined, and conflicts resolved prior to releasing a new official version.