### PR TITLE
Disable multiple expectations rule

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -34,6 +34,9 @@ Rails:
 RSpec/ExampleLength:
   Max: 25
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
As per conversation in #pb-style-council, we would like to disable the `RSpec/MultipleExpectations` rule that limits each example to a single `expect` statement.
