### PR TITLE
Bump version of rubocop gems.

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -31,6 +31,9 @@ Metrics/PerceivedComplexity:
 Rails:
   Enabled: false
 
+RSpec/ContextWording:
+  Enabled: false
+
 RSpec/ExampleLength:
   Max: 25
 
@@ -61,6 +64,10 @@ Style/PercentLiteralDelimiters:
 
 Style/SingleLineBlockParams:
   Enabled: false
+
+Style/StderrPuts:
+  Exclude:
+    - "bin/yarn"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -46,6 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "pry-byebug"
 
-  spec.add_runtime_dependency "rubocop", "~> 0.50.0"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.18.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.51.0"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.20.0"
 end

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -41,10 +41,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter"
-  spec.add_development_dependency "pry-byebug"
 
   spec.add_runtime_dependency "rubocop", "~> 0.51.0"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.20.0"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.50.5".freeze
+  VERSION = "0.51.0".freeze
 end


### PR DESCRIPTION
I would like to bump the `rubocop` gem to get bbatsov/rubocop#4755 which prevents the `Rails/HasManyOrHasOneDependent` cop from failing if a `has_many` association has the `through` option specified.

I took the opportunity to bump `rubocop-rspec` just to keep up.