### PR TITLE
Disable Rails/FilePath and Style/EmptyLiteral cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ezcater_rubocop
 
+## v0.51.1
+- Disable `Rails/FilePath` cop.
+- Disable `Style/EmptyLiteral` cop.
+
+## v0.51.0
+- Update to rubocop v0.51.0 and rubocop-rspec v1.20.0.
+- Disable new cop `RSpec/ContextWording`.
+- Disable `Style/StderrPuts` for `bin/yarn`.
+
 ## v0.50.5
 - Configure `RSpec/NestedGroups` with a `Max` value of 5.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -43,6 +43,9 @@ RSpec/MultipleExpectations:
 RSpec/NestedGroups:
   Max: 5
 
+Style/EmptyLiteral:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -7,6 +7,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/FilePath:
+  Enabled: false
+
 Rails/RelativeDateConstant:
   # Auto-correct is broken for this cops in some cases. It replaces the
   # constant but does not update references to it.

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.51.0".freeze
+  VERSION = "0.51.1".freeze
 end

--- a/lib/rubocop/cop/ezcater/private_attr.rb
+++ b/lib/rubocop/cop/ezcater/private_attr.rb
@@ -76,8 +76,8 @@ module RuboCop
               current_visibility = node.method_name
             elsif ACCESS_AFFECTED_METHODS.include?(node.method_name) && current_visibility != :public
               add_offense(node,
-                          :expression,
-                          format_message(current_visibility, node.method_name))
+                          location: :expression,
+                          message: format_message(current_visibility, node.method_name))
             end
           elsif node.kwbegin_type?
             check_scope(node, current_visibility)

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         def on_send(node)
           example_group_match(node) do |doc|
-            add_offense(doc, :expression, MSG) if doc.source.match?(SELF_DOT_REGEXP)
+            add_offense(doc, location: :expression, message: MSG) if doc.source.match?(SELF_DOT_REGEXP)
           end
         end
 

--- a/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
@@ -37,7 +37,7 @@ module RuboCop
 
           # Finish tree navigation to full line for highlighting
           match_node = match_node.parent while match_node.parent
-          add_offense(match_node, :expression, MSG % node.source)
+          add_offense(match_node, location: :expression, message: MSG % node.source)
         end
 
         private

--- a/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
@@ -33,7 +33,7 @@ module RuboCop
 
           # Finish tree navigation to full line for highlighting
           match_node = match_node.parent while match_node.parent
-          add_offense(match_node, :expression)
+          add_offense(match_node, location: :expression)
         end
 
         private

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -30,7 +30,7 @@ module RuboCop
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)
-          add_offense(match_node, :expression, MSG)
+          add_offense(match_node, location: :expression, message: MSG)
         end
 
         def autocorrect(node)


### PR DESCRIPTION
We've disabled two cops based on recent style council decisions.

Also, the most recent version of rubocop deprecated the form of `add_offense` that we were using in our custom cops.
