### PR TITLE
Configure RSpec/DescribeClass exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ezcater_rubocop
 
+## v0.51.3
+- Configure `RSpec/DescribeClass` to exclude the spec directories which
+  are excluded by explicit metadata.
+
 ## v0.51.2
 - Configure `Style/RaiseArgs` to use the `compact` style.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -34,6 +34,13 @@ Rails:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/DescribeClass:
+  Exclude:
+  - "spec/requests/**/*.rb"
+  - "spec/features/**/*.rb"
+  - "spec/routing/**/*.rb"
+  - "spec/views/**/*.rb"
+
 RSpec/ExampleLength:
   Max: 25
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.51.2".freeze
+  VERSION = "0.51.3".freeze
 end


### PR DESCRIPTION
The `RSpec/DescribeClass` excludes specs that explicitly specify `:request, :feature, :routing, :view` type metadata.

This change configures the cop to exclude the directories where we will infer the same metadata, instead of requiring it to be specified explicitly.