### PR TITLE
Exclude lib/tasks for Metrics/BlockLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.51.3
 - Configure `RSpec/DescribeClass` to exclude the spec directories which
   are excluded by explicit metadata.
+- Exclude `lib/tasks` for the `Metrics/BlockLength` cop.
 
 ## v0.51.2
 - Configure `Style/RaiseArgs` to use the `compact` style.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -13,6 +13,7 @@ Metrics/BlockLength:
   Exclude:
   - "*.gemspec"
   - "spec/**/*.rb"
+  - "lib/tasks/**/*.rake"
 
 Metrics/CyclomaticComplexity:
   Enabled: false


### PR DESCRIPTION
Blocks are often long for rake tasks and I don't think it makes sense to add exceptions for each of the methods in the rake DSL.

Another small config change.