### PR TITLE
Exclude Gemfile from Metrics/LineLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ezcater_rubocop
 
+## v0.51.4
+- Exclude `Gemfile` for the `Metrics/LineLength` cop.
+- Add `system` to the excluded spec directories for `RSpec/DescribeClass`.
+
 ## v0.51.3
 - Configure `RSpec/DescribeClass` to exclude the spec directories which
   are excluded by explicit metadata.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -20,6 +20,8 @@ Metrics/CyclomaticComplexity:
 
 Metrics/LineLength:
   Max: 120
+  Exclude:
+  - "Gemfile"
 
 Metrics/MethodLength:
   Enabled: true
@@ -41,6 +43,7 @@ RSpec/DescribeClass:
   - "spec/features/**/*.rb"
   - "spec/routing/**/*.rb"
   - "spec/views/**/*.rb"
+  - "spec/system/**/*.rb"
 
 RSpec/ExampleLength:
   Max: 25

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.51.3".freeze
+  VERSION = "0.51.4".freeze
 end


### PR DESCRIPTION
## What did we change?

Add exclusion for `Gemfile` for `Metrics/LineLength`.

Add `system` to the excluded spec directories for `RSpec/DescribeClass`.

## Why are we doing this?

In several repos we have disabled the `Metrics/LineLength` cop for the `Gemfile`. This moves that configuration to this gem.

The update to the configuration of `RSpec/DescribeClass` is to keep up with the types of specs that are excluded by explicit metadata.

## How was it tested?
- [x] Specs
- [x] Locally
