### PR TITLE
0.49.5: Gql error helpers Cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+# v0.49.4
+- Add `Ezcater/RspecRequireGqlErrorHelpers` cop.
+
 # v0.49.3
 - Do not apply `Ezcater/StyleDig` to access using a range.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ is updated.
 1. [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) - Enforce ".<class method>" instead of "self.<class method>" for example group description.
 1. [RspecRequireBrowserMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb) - Enforce use of `mock_ezcater_app`, `mock_chrome_browser` & `mock_custom_browser` helpers instead of mocking `Browser` or `EzBrowser` directly.
 1. [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforce use of `mock_feature_flag` helper instead of mocking `FeatureFlag.is_active?` directly.
+1. [RspecRequireGqlErrorHelpers](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_gql_error_helpers.rb) - Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.
 1. [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) - Recommend `dig` for deeply nested access.
 
 ## Development

--- a/config/default.yml
+++ b/config/default.yml
@@ -16,6 +16,10 @@ Ezcater/RspecRequireFeatureFlagMock:
   Include:
     - '**/*_spec.rb'
 
+Ezcater/RspecRequireGqlErrorHelpers:
+  Description: 'Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.'
+  Enabled: true
+
 Ezcater/StyleDig:
   Description: 'Recommend `dig` for deeply nested access.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -14,5 +14,6 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/rspec_require_browser_mock"
 require "rubocop/cop/ezcater/rspec_require_feature_flag_mock"
+require "rubocop/cop/ezcater/rspec_require_gql_error_helpers"
 require "rubocop/cop/ezcater/rspec_dot_not_self_dot"
 require "rubocop/cop/ezcater/style_dig"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.49.3".freeze
+  VERSION = "0.49.4".freeze
 end

--- a/lib/rubocop/cop/ezcater/rspec_require_gql_error_helpers.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_gql_error_helpers.rb
@@ -1,0 +1,35 @@
+module RuboCop
+  module Cop
+    module Ezcater
+      # Enforce use of GQLErrors helpers instead of throwing
+      # GraphQL::ExecutionErrors directly
+      #
+      # @example
+      #
+      #   # good
+      #   GQLErrors.summary_error("An error occurred")
+      #   GQLErrors.request_error("You can't access this", 401)
+      #   GQLErrors.field_error("is invalid", :first_name, "First Name")
+      #   GQLErrors.field_errors_for(my_model, context)
+      #   GQLErrors.field_errors_for(my_model, context, summary_error: "An error occurred")
+      #   GQLErrors.field_errors_for(my_model, context, field_mapping: { first: :first_name })
+      #
+      #   # bad
+      #   GraphQL::ExecutionError.new("An error occurred")
+      #   GraphQL::ExecutionError.new("You can't access this", options: { status_code: 401 })
+      class RspecRequireGqlErrorHelpers < Cop
+        MSG = "Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.".freeze
+
+        def_node_matcher :graphql_const?, <<~PATTERN
+          (const (const _ :GraphQL) :ExecutionError)
+        PATTERN
+
+        def on_const(node)
+          return unless graphql_const?(node)
+
+          add_offense(node, :expression, MSG)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/rspec_require_gql_error_helpers_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_gql_error_helpers_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::Ezcater::RspecRequireGqlErrorHelpers, :config do
+  subject(:cop) { described_class.new }
+
+  let(:error_message) { described_class::MSG }
+  let(:expected_source) { "GraphQL::ExecutionError" }
+
+  context "when attempting to directly use GraphQL::ExecutionError" do
+    it "registers an offense" do
+      source = "error.is_a? GraphQL::ExecutionError"
+      inspect_source(cop, source)
+      expect(cop.messages).to eq([error_message])
+      expect(cop.highlights).to eq([expected_source])
+    end
+
+    context "and instantiate a new instance" do
+      it "registers an offense" do
+        source = "GraphQL::ExecutionError.new(\"An error occurred\")"
+        inspect_source(cop, source)
+        expect(cop.messages).to eq([error_message])
+        expect(cop.highlights).to eq([expected_source])
+      end
+
+      context "and additional options are provided" do
+        it "registers an offense" do
+          source = "GraphQL::ExecutionError.new(\"An error occurred\", options: { status_code: 401 })"
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([error_message])
+          expect(cop.highlights).to eq([expected_source])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enforces use of the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.

**Backwards compatibility release for ez-rails**