### PR TITLE
Exclude config/environments/*.rb for Metrics/BlockLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.51.6
+- Exclude `config/environments/*.rb` for the `Metrics/BlockLength` cop.
+
 ## v0.51.5
 - Add `Ezcater/RspecRequireGqlErrorHelpers` cop.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -14,6 +14,7 @@ Metrics/BlockLength:
   - "*.gemspec"
   - "spec/**/*.rb"
   - "lib/tasks/**/*.rake"
+  - "config/environments/*.rb"
 
 Metrics/CyclomaticComplexity:
   Enabled: false

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.51.5".freeze
+  VERSION = "0.51.6".freeze
 end


### PR DESCRIPTION
The blocks in these files for configuration tend to get lengthy, and we already have exclusions inside the files for several apps.

I was surprised that this is not already part of our shared configuration.