### PR TITLE
Add RailsConfiguration cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ezcater_rubocop
 
 ## v0.51.6
+- Add `Ezcater/RailsConfiguration` cop.
 - Exclude `config/environments/*.rb` for the `Metrics/BlockLength` cop.
 
 ## v0.51.5

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ is updated.
 
 ## Custom Cops
 1. [PrivateAttr](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/private_attr.rb) - Require methods from the `private_attr` gem.
+1. [RailsConfiguration](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rails_configuration.rb) - Enforce use of `Rails.configuration` instead of `Rails.application.config`.
 1. [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) - Enforce ".<class method>" instead of "self.<class method>" for example group description.
 1. [RspecRequireBrowserMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb) - Enforce use of `mock_ezcater_app`, `mock_chrome_browser` & `mock_custom_browser` helpers instead of mocking `Browser` or `EzBrowser` directly.
 1. [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforce use of `mock_feature_flag` helper instead of mocking `FeatureFlag.is_active?` directly.

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,10 @@ Ezcater/PrivateAttr:
   Description: 'Require methods from the private_attr gem'
   Enabled: true
 
+Ezcater/RailsConfiguration:
+  Description: 'Enforce the use of `Rails.configuration` instead of `Rails.application.config`.'
+  Enabled: true
+
 Ezcater/RspecDotNotSelfDot:
   Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -13,6 +13,7 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/private_attr"
+require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rspec_require_browser_mock"
 require "rubocop/cop/ezcater/rspec_require_feature_flag_mock"
 require "rubocop/cop/ezcater/rspec_require_gql_error_helpers"

--- a/lib/rubocop/cop/ezcater/rails_configuration.rb
+++ b/lib/rubocop/cop/ezcater/rails_configuration.rb
@@ -1,0 +1,26 @@
+module RuboCop
+  module Cop
+    module Ezcater
+      class RailsConfiguration < Cop
+        MSG = "Use `Rails.configuration` instead of `Rails.application.config`.".freeze
+        RAILS_CONFIGURATION = "Rails.configuration".freeze
+
+        def_node_matcher "rails_application_config", <<-PATTERN
+          (send (send (const _ :Rails) :application) :config)
+        PATTERN
+
+        def on_send(node)
+          rails_application_config(node) do
+            add_offense(node, location: :expression, message: MSG)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, RAILS_CONFIGURATION)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/rails_configuration_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_configuration_spec.rb
@@ -1,0 +1,22 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::RailsConfiguration do
+  subject(:cop) { described_class.new }
+
+  let(:msgs) { [described_class::MSG] }
+
+  it "accepts Rails.configuration" do
+    source = "Rails.configuration.foobar"
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "corrects Rails.application.config" do
+    source = "Rails.application.config.foobar"
+    inspect_source(source)
+    expect(cop.highlights).to eq(["Rails.application.config"])
+    expect(cop.messages).to eq(msgs)
+    expect(autocorrect_source(source)).to eq("Rails.configuration.foobar")
+  end
+end


### PR DESCRIPTION
Add a custom cop to ensure the use of `Rails.configuration` instead of `Rails.application.config`.