### PR TITLE
Rename `RspecRequireGqlErrorHelpers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.49.6
+- Rename `Ezcater/RspecRequireGqlErrorHelpers` cop to `Ezcater/RequireGqlErrorHelpers`.
+
 ## v0.49.5
 - Add `Ezcater/RailsConfiguration` cop.
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ is updated.
 
 ## Custom Cops
 1. [RailsConfiguration](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rails_configuration.rb) - Enforce use of `Rails.configuration` instead of `Rails.application.config`.
+1. [RequireGqlErrorHelpers](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb) - Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.
 1. [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) - Enforce ".<class method>" instead of "self.<class method>" for example group description.
 1. [RspecRequireBrowserMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb) - Enforce use of `mock_ezcater_app`, `mock_chrome_browser` & `mock_custom_browser` helpers instead of mocking `Browser` or `EzBrowser` directly.
 1. [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforce use of `mock_feature_flag` helper instead of mocking `FeatureFlag.is_active?` directly.
-1. [RspecRequireGqlErrorHelpers](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_gql_error_helpers.rb) - Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.
 1. [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) - Recommend `dig` for deeply nested access.
 
 ## Development

--- a/config/default.yml
+++ b/config/default.yml
@@ -20,7 +20,7 @@ Ezcater/RspecRequireFeatureFlagMock:
   Include:
     - '**/*_spec.rb'
 
-Ezcater/RspecRequireGqlErrorHelpers:
+Ezcater/RequireGqlErrorHelpers:
   Description: 'Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.'
   Enabled: true
 

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -13,8 +13,8 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/rails_configuration"
+require "rubocop/cop/ezcater/require_gql_error_helpers"
 require "rubocop/cop/ezcater/rspec_require_browser_mock"
 require "rubocop/cop/ezcater/rspec_require_feature_flag_mock"
-require "rubocop/cop/ezcater/rspec_require_gql_error_helpers"
 require "rubocop/cop/ezcater/rspec_dot_not_self_dot"
 require "rubocop/cop/ezcater/style_dig"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.49.5".freeze
+  VERSION = "0.49.6".freeze
 end

--- a/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb
+++ b/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   # bad
       #   GraphQL::ExecutionError.new("An error occurred")
       #   GraphQL::ExecutionError.new("You can't access this", options: { status_code: 401 })
-      class RspecRequireGqlErrorHelpers < Cop
+      class RequireGqlErrorHelpers < Cop
         MSG = "Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.".freeze
 
         def_node_matcher :graphql_const?, <<~PATTERN

--- a/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
+++ b/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe RuboCop::Cop::Ezcater::RspecRequireGqlErrorHelpers, :config do
+RSpec.describe RuboCop::Cop::Ezcater::RequireGqlErrorHelpers, :config do
   subject(:cop) { described_class.new }
 
   let(:error_message) { described_class::MSG }


### PR DESCRIPTION
The Rspec prefix doesn't make sense on this cop, and was a result of a
bit of copy pasta. Removing it and naming the final cop `RequireGqlErrorHelpers`

I went with `RequireGqlErrorHelpers` over `PreventGraphQLExecutionErrorInvokation` since this cop is directly related to `GQLErrors` by virtue of the error message displayed when `GraphQL::ExecutionError` is used.