### PR TITLE
Update to rubocop v0.52.1 and rubocop-rspec 1.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.0 (unreleased)
+- Update to rubocop v0.52.1 and rubocop-rspec v1.22.2.
+
 ## v0.51.8
 - Disable `RSpec/LetSetup` cop.
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -15,3 +15,7 @@ Rails/RelativeDateConstant:
   # constant but does not update references to it.
   AutoCorrect: false
 
+Style/MixinUsage:
+  Exclude:
+  - "bin/**/*"
+

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -46,6 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter"
 
-  spec.add_runtime_dependency "rubocop", "~> 0.51.0"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.20.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.52.1"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.22.2"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.51.8".freeze
+  VERSION = "0.52.0.rc0".freeze
 end

--- a/lib/rubocop/cop/ezcater/private_attr.rb
+++ b/lib/rubocop/cop/ezcater/private_attr.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         ACCESS_AFFECTED_METHODS = (ATTR_METHODS + %i(alias_method)).to_set.freeze
 
-        MSG = "Use `%s_%s` instead".freeze
+        MSG = "Use `%<visibility>s_%<method_name>s` instead".freeze
 
         def on_class(node)
           check_node(node.children[2]) # class body
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def format_message(visibility, method_name)
-          format(MSG, visibility, method_name)
+          format(MSG, visibility: visibility, method_name: method_name)
         end
 
         def check_scope(node, current_visibility = :public)

--- a/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   allow(Browser).to receive...
       #   allow(EzBrowser).to receive...
       class RspecRequireBrowserMock < Cop
-        MSG = "Use the mocks provided by `BrowserHelpers` instead of mocking `%s`".freeze
+        MSG = "Use the mocks provided by `BrowserHelpers` instead of mocking `%<node_source>s`".freeze
 
         def_node_matcher :browser_const?, <<~PATTERN
           (const _ {:Browser :EzBrowser})
@@ -37,7 +37,9 @@ module RuboCop
 
           # Finish tree navigation to full line for highlighting
           match_node = match_node.parent while match_node.parent
-          add_offense(match_node, location: :expression, message: MSG % node.source)
+          add_offense(match_node,
+                      location: :expression,
+                      message: format(MSG, node_source: node.source))
         end
 
         private

--- a/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.shared_examples_for "a browser class that should be mocked" do |klass|
-  let(:error_message) { described_class::MSG % klass }
+  let(:error_message) { format(described_class::MSG, node_source: klass) }
 
   context "when the class is '#{klass}'" do
     it "registers an offense when attempting to directly mock #{klass}" do


### PR DESCRIPTION
This updates this gem to use the latest releases of the rubocop gems that it depends on.

The only offenses that I had to correct in the code for this gem were for `Style/FormatStringToken`.

I've excluded file in the `bin/` directory for the new cop `Style/MixinUsage`. I added this configuration for Rails apps because Rails-generated files in the `bin/` directory violate this cop, that flags `include` at the top-level.

These changes were tested out with:
- identity: https://github.com/ezcater/ezcater-identity/pull/112
- delivery: https://github.com/ezcater/ezcater-delivery/pull/218

I was tempted to require Ruby 2.4 with this release. I held off on that because the `tools` repo was recently updated to use this gem (at v0.51.8) but it is using 2.3.3.

I would be interested in eventually implementing the disabled-by-default `Layout/ClassStructure` but I've also held off on that for now as I expect it will require a separate conversation.