### PR TITLE
Allow staging as rails env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.1 (unreleased)
+- Allow staging as a rails environment for the Rails/UnknownEnv cop.
+
 ## v0.52.0
 - Update to rubocop v0.52.1 and rubocop-rspec v1.22.2.
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -19,3 +19,9 @@ Style/MixinUsage:
   Exclude:
   - "bin/**/*"
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - staging
+    - production


### PR DESCRIPTION
"staging" is not one of the default envs for this cop. so i added it
along with being explicit about the other 3. this is a bug fix so i only bumped the tiny/patch version number

(didnt tag tim so he can enjoy his vacation :smiley: ) 