### PR TITLE
Disable the `Style/IfUnlessModifier` cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.2
+- Disable `Style/IfUnlessModifier` cop.
+
 ## v0.52.1
 - Allow staging as a rails environment for the Rails/UnknownEnv cop.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -67,6 +67,9 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 # This cop does not yet support a style to prevent underscores
 Style/NumericLiterals:
   Enabled: false

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.52.1".freeze
+  VERSION = "0.52.2".freeze
 end


### PR DESCRIPTION
We felt that this rule wasn’t helping and wasn’t something we necessarily want to enforce.