### PR TITLE
Exclude spec/integrations for RSpec/DescribeClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.3 (unreleased)
+- Exclude `spec/integrations` for `RSpec/DescribeClass`.
+
 ## v0.52.2
 - Disable `Style/IfUnlessModifier` cop.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -45,6 +45,7 @@ RSpec/DescribeClass:
   - "spec/routing/**/*.rb"
   - "spec/views/**/*.rb"
   - "spec/system/**/*.rb"
+  - "spec/integrations/**/*.rb"
 
 RSpec/ExampleLength:
   Max: 25

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.52.2".freeze
+  VERSION = "0.52.3".freeze
 end


### PR DESCRIPTION
## What did we change?

Excluded the `spec/integrations` for `RSpec/DescribeClass`.

## Why are we doing this?

Integration tests are another type of test where it does not make sense to require that the top-level describe is a class.

## How was it tested?
- [ ] Specs
- [ ] Locally