### PR TITLE
Disable Style/GuardClause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.3
+- Disable `Style/GuardClause` cop.
+
 ## v0.52.2
 - Disable `Style/IfUnlessModifier` cop.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -64,6 +64,9 @@ Style/EmptyLiteral:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.52.2".freeze
+  VERSION = "0.52.3".freeze
 end


### PR DESCRIPTION
## What did we change?

Disabled the `Style/GuardClause` cop.

## Why are we doing this?

I figured I'd just open a PR to discuss this.

This cop tries to prevent you from wrapping code unnecessarily inside conditional expressions.

However, similar to the `Style/IfUnlessModifier` cop that we recently modified this can lead to important condition expressions being pushed into if/unless modifiers.

I'm in favor of using guard clauses in some cases, but I don't think this is something that we need to enforce consistency around.

Here is the pattern where this has bitten me most often:

```ruby
# original code
if important_condition
  do_normal_processing
else
  raise SomeCustomException.new("possibly with a long message")
end

# the cop wants
raise SomeCustomException.new("possibly with a long message") unless important_condition
do_normal_processing
```

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging