### PR TITLE
 Configure Style/RegexpLiteral with AllowInnerSlashes=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.4
+- Configure `Style/RegexpLiteral` cop with the `AllowInnerSlashes: true` option.
+
 ## v0.52.3
 - Disable `Style/GuardClause` cop.
 - Exclude `spec/integrations` for `RSpec/DescribeClass`.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -90,6 +90,11 @@ Style/PercentLiteralDelimiters:
 Style/RaiseArgs:
   EnforcedStyle: compact
 
+Style/RegexpLiteral:
+  Enabled: true
+  EnforcedStyle: slashes
+  AllowInnerSlashes: true
+
 Style/SingleLineBlockParams:
   Enabled: false
 

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
                       Rakefile)
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(/^(test|spec|features)\//)
   end - excluded_files
   spec.bindir = "bin"
   spec.executables << "circle_rubocop.rb"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.52.3".freeze
+  VERSION = "0.52.4".freeze
 end


### PR DESCRIPTION
## What did we change?

Configuration for `Style/RegexpLiteral`.

## Why are we doing this?

We didn't want to force the use of `%r` when a regexp contains escaped forward slashes.

After changing the configuration here, there was actually an offense in the gemspec. I wasn't anticipating this. It looks like with this configuration it is requiring `//` even if regexp contains a forward slash.

I'm okay with that, but also feel that this is an edge case. So I'm also happy to abandon this change if the council things we should require `%r` instead of `//` if there are forward slashes.

## How was it tested?
- [ ] Specs
- [ ] Locally