### PR TITLE
Configure Style/TrailingCommaInLiteral with consistent_comma style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.6
+- Configure `Style/TrailingCommaInLiteral` with `consistent_comma` style.
+
 ## v0.52.5
 - Add `Ezcater/RspecMatchOrderedArray` cop.
 - Fix array equality matcher violations in specs.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -104,3 +104,7 @@ Style/StderrPuts:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.52.5".freeze
+  VERSION = "0.52.6".freeze
 end

--- a/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireFeatureFlagMock, :config do
   it "accepts usage of the mock_feature_flag helper with options" do
     inspect_source([
                      "user = create(:user)",
-                     "mock_feature_flag(\"MyFeatureFlag\", { user: user }, true)"
+                     "mock_feature_flag(\"MyFeatureFlag\", { user: user }, true)",
                    ])
     expect(cop.offenses).to be_empty
   end


### PR DESCRIPTION
## What did we change?

Configured a cop with the style agreed upon by the Style Council.

## Why are we doing this?

To enforce a consistent style that reduces code diffs.

## How was it tested?
- [x] Specs
- [x] Locally