### PR TITLE
 Enable and configure Style/FrozenStringLiteralComment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.7
+- Enable `Style/FrozenStringLiteralComment` with the `when_needed` style.
+
 ## v0.52.6
 - Configure `Style/TrailingCommaInLiteral` with `consistent_comma` style.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/bin/circle_rubocop.rb
+++ b/bin/circle_rubocop.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "English"
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "ezcater_rubocop"

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -63,7 +63,8 @@ Style/EmptyLiteral:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: when_needed
 
 Style/GuardClause:
   Enabled: false

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ezcater_rubocop/version"

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ezcater_rubocop/version"
 require "rubocop-rspec"
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EzcaterRubocop
-  VERSION = "0.52.7".freeze
+  VERSION = "0.52.7"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,3 +1,3 @@
 module EzcaterRubocop
-  VERSION = "0.52.6".freeze
+  VERSION = "0.52.7".freeze
 end

--- a/lib/rubocop/cop/ezcater/private_attr.rb
+++ b/lib/rubocop/cop/ezcater/private_attr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -42,7 +44,7 @@ module RuboCop
 
         ACCESS_AFFECTED_METHODS = (ATTR_METHODS + %i(alias_method)).to_set.freeze
 
-        MSG = "Use `%<visibility>s_%<method_name>s` instead".freeze
+        MSG = "Use `%<visibility>s_%<method_name>s` instead"
 
         def on_class(node)
           check_node(node.children[2]) # class body

--- a/lib/rubocop/cop/ezcater/rails_configuration.rb
+++ b/lib/rubocop/cop/ezcater/rails_configuration.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
       class RailsConfiguration < Cop
-        MSG = "Use `Rails.configuration` instead of `Rails.application.config`.".freeze
-        RAILS_CONFIGURATION = "Rails.configuration".freeze
+        MSG = "Use `Rails.configuration` instead of `Rails.application.config`."
+        RAILS_CONFIGURATION = "Rails.configuration"
 
         def_node_matcher "rails_application_config", <<-PATTERN
           (send (send (const _ :Rails) :application) :config)

--- a/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb
+++ b/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -18,7 +20,7 @@ module RuboCop
       #   GraphQL::ExecutionError.new("An error occurred")
       #   GraphQL::ExecutionError.new("You can't access this", options: { status_code: 401 })
       class RequireGqlErrorHelpers < Cop
-        MSG = "Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.".freeze
+        MSG = "Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly."
 
         def_node_matcher :graphql_const?, <<~PATTERN
           (const (const _ :GraphQL) :ExecutionError)

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -17,7 +19,7 @@ module RuboCop
       #   end
       class RspecDotNotSelfDot < Cop
         SELF_DOT_REGEXP = /["']self\./
-        MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'.freeze
+        MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'
 
         def_node_matcher :example_group_match, <<-PATTERN
           (send _ #{RuboCop::RSpec::Language::ExampleGroups::ALL.node_pattern_union} $_ ...)

--- a/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
+++ b/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -13,9 +15,9 @@ module RuboCop
       #   expect(foo).to eq([1, 2, 3])
       #   expect(foo).to eq [1, 2, 3]
       class RspecMatchOrderedArray < Cop
-        MATCH_ORDERED_ARRAY = "match_ordered_array".freeze
+        MATCH_ORDERED_ARRAY = "match_ordered_array"
         MSG = "Use the `match_ordered_array` matcher from ezcater_matchers gem "\
-          "instead of `eq` when comparing collections".freeze
+          "instead of `eq` when comparing collections"
 
         def_node_matcher "eq_array", <<~PATTERN
           (send nil? :eq (array ...))

--- a/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -18,7 +20,7 @@ module RuboCop
       #   allow(Browser).to receive...
       #   allow(EzBrowser).to receive...
       class RspecRequireBrowserMock < Cop
-        MSG = "Use the mocks provided by `BrowserHelpers` instead of mocking `%<node_source>s`".freeze
+        MSG = "Use the mocks provided by `BrowserHelpers` instead of mocking `%<node_source>s`"
 
         def_node_matcher :browser_const?, <<~PATTERN
           (const _ {:Browser :EzBrowser})

--- a/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -14,7 +16,7 @@ module RuboCop
       #   allow(FeatureFlag).to receive(:is_active?).with("MyFeatureFlag").and_return(true)
       #   allow(FeatureFlag).to receive(:is_active?).with("MyFeatureFlag", user: current_user).and_return(true)
       class RspecRequireFeatureFlagMock < Cop
-        MSG = "Use the `mock_feature_flag` helper instead of mocking `allow(FeatureFlag)`".freeze
+        MSG = "Use the `mock_feature_flag` helper instead of mocking `allow(FeatureFlag)`"
 
         def_node_matcher :feature_flag_const?, <<~PATTERN
           (const _ :FeatureFlag)

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Ezcater
@@ -19,7 +21,7 @@ module RuboCop
 
         minimum_target_ruby_version 2.3
 
-        MSG = "Use `dig` for nested access.".freeze
+        MSG = "Use `dig` for nested access."
 
         def_node_matcher :nested_access_match, <<-PATTERN
           (send (send (send _receiver !:[]) :[] !{irange erange}) :[] !{irange erange})

--- a/lib/rubocop/rspec/language/each_selector.rb
+++ b/lib/rubocop/rspec/language/each_selector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Monkey-patch SelectorSet to allow enumeration of selectors.
 
 module RuboCop

--- a/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
+++ b/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe RuboCop::Cop::Ezcater::RequireGqlErrorHelpers, :config do

--- a/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.shared_examples_for "a browser class that should be mocked" do |klass|

--- a/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe RuboCop::Cop::Ezcater::RspecRequireFeatureFlagMock, :config do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "ezcater_rubocop"
 require "rspec"


### PR DESCRIPTION
## What did we change?

Enabled the `Style/FrozenStringLiteralComment` cop with the `when_needed` style, and auto-corrected offenses here.

## Why are we doing this?

To implement the recent Style Council decision.

I hope the council doesn't mind me jumping on implementing this. I'll tag everyone on the council, and release once this gets two approvals.

There are two commits here. The second is auto-correct based on the configuration change.

## How was it tested?
- [x] Specs
- [x] Locally
