### PR TITLE
Add configuration for use with gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.52.8
+- Add new configuration `rubocop_gem` for use with gems.
+
 ## v0.52.7
 - Enable `Style/FrozenStringLiteralComment` with the `when_needed` style.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Further customization of RuboCop for your local project may be added to this fil
 
 - **rubocop**: Assumes RSpec is used and requires [rubocop-rspec](https://github.com/backus/rubocop-rspec).
   This configuration should be used for gems.
+- **rubocop_gem**: For use in Ruby gem projects, this inherits from the **rubocop** configuration.
 - **rubocop_rails**: For Rails projects, this inherits from the **rubocop** configuration.
 
 ## Usage

--- a/conf/rubocop_gem.yml
+++ b/conf/rubocop_gem.yml
@@ -1,0 +1,7 @@
+inherit_from:
+  - ../conf/rubocop.yml
+
+AllCops:
+  Exclude:
+    - 'vendor/bundle/**/*'
+    - 'gemfiles/vendor/**/*' 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.52.7"
+  VERSION = "0.52.8"
 end


### PR DESCRIPTION
## What did we change?

Added a new configuration for gems.

## Why are we doing this?

After adding this customization locally for a couple of gems, I decided to just create a new configuration.

The exclusion of `vendor/bundle` is the default from rubocop, but has to be repeated here since we are overriding it. The `gemfiles` directory comes from use of the [appraisal](https://github.com/thoughtbot/appraisal) gem. But it doesn't hurt to have it even if the gem is (not yet) setup with appraisal.

## How was it tested?
- [x] Specs
- [ ] Locally