### PR TITLE
Upgrade to rubocop v0.57.2 and rubocop-rspec v1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   https://github.com/rubocop-hq/rubocop-rspec/issues/655.
 - Configure `Naming/UncommunicativeMethodParamName` to allow `e, ex, id`
   param names.
+- Exclude appraisal generated gemfiles for gems.
 
 ## v0.52.8
 - Add new configuration `rubocop_gem` for use with gems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Update to rubocop v0.57.2 and rubocop-rspec v1.27.0.
 - Disable new cop `Naming/MemoizedInstanceVariableName` until configuration
   options are available.
+- Disable `FactoryBot/DynamicAttributeDefinedStatically` due to
+  https://github.com/rubocop-hq/rubocop-rspec/issues/655.
+- Configure `Naming/UncommunicativeMethodParamName` to allow `e, ex, id`
+  param names.
 
 ## v0.52.8
 - Add new configuration `rubocop_gem` for use with gems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.57.0 (unreleased)
+- Update to rubocop v0.57.2 and rubocop-rspec v1.27.0.
+
 ## v0.52.8
 - Add new configuration `rubocop_gem` for use with gems.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.57.0 (unreleased)
 - Update to rubocop v0.57.2 and rubocop-rspec v1.27.0.
+- Disable new cop `Naming/MemoizedInstanceVariableName` until configuration
+  options are available.
 
 ## v0.52.8
 - Add new configuration `rubocop_gem` for use with gems.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 ezCater, Inc
+Copyright (c) 2017-2018 ezCater, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -106,6 +106,9 @@ Style/StderrPuts:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -3,6 +3,11 @@ require: ezcater_rubocop
 AllCops:
   DisplayCopNames: true
 
+# This is a useful cop but produces some false positives and can break code:
+# https://github.com/rubocop-hq/rubocop-rspec/issues/655
+FactoryBot/DynamicAttributeDefinedStatically:
+  Enabled: false
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 
@@ -35,6 +40,12 @@ Metrics/PerceivedComplexity:
 # Disable this cop until configuration options are available (>= 0.58.0)
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+  - e
+  - ex
+  - id
 
 Rails:
   Enabled: false

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -32,6 +32,10 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+# Disable this cop until configuration options are available (>= 0.58.0)
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
 Rails:
   Enabled: false
 

--- a/conf/rubocop_gem.yml
+++ b/conf/rubocop_gem.yml
@@ -5,3 +5,4 @@ AllCops:
   Exclude:
     - 'vendor/bundle/**/*'
     - 'gemfiles/vendor/**/*' 
+    - 'gemfiles/*.gemfile'

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter"
 
+  spec.add_runtime_dependency "parser", "< 2.5.0.1"
   spec.add_runtime_dependency "rubocop", "~> 0.57.2"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.27.0"
 end

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ezcater_rubocop/version"
 
@@ -48,6 +48,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter"
 
-  spec.add_runtime_dependency "rubocop", "~> 0.52.1"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.22.2"
+  spec.add_runtime_dependency "rubocop", "~> 0.57.2"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.27.0"
 end

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter"
 
-  spec.add_runtime_dependency "parser", "< 2.5.0.1"
+  spec.add_runtime_dependency "parser"
   spec.add_runtime_dependency "rubocop", "~> 0.57.2"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.27.0"
 end

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -5,7 +5,7 @@ require "rubocop-rspec"
 
 # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
 # bit of our configuration. Based on approach from rubocop-rspec:
-DEFAULT_FILES = File.expand_path("../../config/default.yml", __FILE__)
+DEFAULT_FILES = File.expand_path("../config/default.yml", __dir__)
 
 path = File.absolute_path(DEFAULT_FILES)
 hash = RuboCop::ConfigLoader.send(:load_yaml_configuration, path)

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.52.8"
+  VERSION = "0.57.0.rc0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.0.rc2"
+  VERSION = "0.57.0.rc3"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.0.rc1"
+  VERSION = "0.57.0.rc2"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.0.rc0"
+  VERSION = "0.57.0.rc1"
 end

--- a/spec/rubocop/cop/ezcater/private_attr_spec.rb
+++ b/spec/rubocop/cop/ezcater/private_attr_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe RuboCop::Cop::Ezcater::PrivateAttr do
       context "when `#{access_modifier}` is applied to `#{method_name}`" do
         it "registers an offense" do
           expect_offense(<<-RUBY.strip_indent)
-        class C
-          #{access_modifier}
+            class C
+              #{access_modifier}
 
-          #{method_name} :foo
-          #{'^' * (method_name.size + 5)} Use `#{access_modifier}_#{method_name}` instead
-        end
+              #{method_name} :foo
+              #{'^' * (method_name.size + 5)} Use `#{access_modifier}_#{method_name}` instead
+            end
           RUBY
         end
       end
@@ -21,13 +21,13 @@ RSpec.describe RuboCop::Cop::Ezcater::PrivateAttr do
       context "when `#{access_modifier}` is applied to `#{method_name}` across multiple lines" do
         it "registers an offense" do
           expect_offense(<<-RUBY.strip_indent)
-        class C
-          #{access_modifier}
+            class C
+              #{access_modifier}
 
-          #{method_name} :foo,
-          #{'^' * (method_name.size + 6)} Use `#{access_modifier}_#{method_name}` instead
-                         :bar
-        end
+              #{method_name} :foo,
+              #{'^' * (method_name.size + 6)} Use `#{access_modifier}_#{method_name}` instead
+                             :bar
+            end
           RUBY
         end
       end
@@ -35,11 +35,11 @@ RSpec.describe RuboCop::Cop::Ezcater::PrivateAttr do
       context "when `#{access_modifier}` is applied after `#{method_name}`" do
         it "doesn't register an offense" do
           expect_no_offenses(<<-RUBY.strip_indent)
-        class C
-          #{method_name} :foo
+            class C
+              #{method_name} :foo
 
-          #{access_modifier}
-        end
+              #{access_modifier}
+            end
           RUBY
         end
       end
@@ -47,11 +47,11 @@ RSpec.describe RuboCop::Cop::Ezcater::PrivateAttr do
       context "when `protected` is applied after `#{method_name}`" do
         it "doesn't register an offense" do
           expect_no_offenses(<<-RUBY.strip_indent)
-        class C
-          #{method_name} :foo
+            class C
+              #{method_name} :foo
 
-          protected
-        end
+              protected
+            end
           RUBY
         end
       end
@@ -60,12 +60,12 @@ RSpec.describe RuboCop::Cop::Ezcater::PrivateAttr do
     context "when `#{access_modifier}` is applied to `alias_method`" do
       it "registers an offense" do
         expect_offense(<<-RUBY.strip_indent)
-      class C
-        #{access_modifier}
+          class C
+            #{access_modifier}
 
-        alias_method :new_foo, :foo
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{access_modifier}_alias_method` instead
-      end
+            alias_method :new_foo, :foo
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{access_modifier}_alias_method` instead
+          end
         RUBY
       end
     end

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -1,9 +1,10 @@
 # encoding utf-8
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config, :ruby23 do
+RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:ruby_version) { 2.3 }
   let(:msgs) { [described_class::MSG] }
 
   it "accepts non-nested access" do


### PR DESCRIPTION
## What did we change?

Updated rubocop and rubocop-rspec to the latest releases.

Configure new cops:
- `Naming/MemoizedInstanceVariableName` is disabled because it does not allow an underscore (_) prefix on instance variable names. This is coming in the next release.
- `FactoryBot/DynamicAttributeDefinedStatically` is disabled due to a false positive found with ezcater-delivery. Issue opened [#655](https://github.com/rubocop-hq/rubocop-rspec/issues/655).
- `Naming/UncommunicativeMethodParamName` is configured to allow `e, ex, id` as param names.

## Why are we doing this?

To get current with rubocop updates.

Some of the new cops required changes to the repos that I tested (linked below). Most of the new offenses that I saw were from `Style/ExpandPathArguments`, and I've corrected those.

Of the cops that were problematic, I'm on the fence about the `Naming/UncommunicativeMethodParamName` cop. Anyway, it is up to the council if we want to enable it or how we want to configure it.

Updated repos for results:
- https://github.com/ezcater/ezcater-delivery/compare/tjwp/rubocop-0.57?expand=1
- https://github.com/ezcater/ezcater-identity/compare/tjwp/rubocop-0.57?expand=1
- https://github.com/ezcater/ezcater_kafka/compare/tjwp/rubocop-0.57?expand=1

## How was it tested?
- [x] Specs
- [x] Locally
