### PR TITLE
Fix `Ezcater/RspecRequireHttpStatusMatcher` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.57.2
+- Fix `Ezcater/RspecRequireHttpStatusMatcher` cop.
+
 ## v0.57.1
 - Add `Ezcater/RspecRequireHttpStatusMatcher` cop.
 - Enable `Rails/HttpStatus` cop and enforce symbols.

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.1"
+  VERSION = "0.57.2"
 end

--- a/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb
@@ -18,12 +18,16 @@ module RuboCop
         MSG = "Use the `have_http_status` matcher, like `expect(response).to have_http_status :bad_request`, "\
           "rather than `%<node_source>s`"
 
+        def_node_matcher :response_status_assertion, <<~PATTERN
+          (send (send _ :expect (send (send _ :response) :status)) :to (send _ :eq (int _)))
+        PATTERN
+
         def_node_matcher :response_code_assertion, <<~PATTERN
-          (send (send _ :expect (send (send _ :response) :code)) :to (send _ :eq (int _)))
+          (send (send _ :expect (send (send _ :response) :code)) :to (send _ :eq (str _)))
         PATTERN
 
         def on_send(node)
-          return unless response_code_assertion(node)
+          return if !response_status_assertion(node) && !response_code_assertion(node)
 
           add_offense(node,
                       location: :expression,

--- a/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireHttpStatusMatcher do
   end
 
   it "registers an offence when attempting to assert directly on the status" do
-    inspect_source("expect(response.code).to eq 400")
+    inspect_source("expect(response.status).to eq 400")
     expect(cop.messages).to match_array(["Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq 400`",])
+      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`",])
+  end
+
+  it "registers an offence when attempting to assert directly on the code" do
+    inspect_source("expect(response.code).to eq \"400\"")
+    expect(cop.messages).to match_array(["Use the `have_http_status` matcher, like "\
+      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq \"400\"`",])
   end
 end


### PR DESCRIPTION
## What did we change?

Fix `Ezcater/RspecRequireHttpStatusMatcher` cop

## Why are we doing this?

Previously this was looking for `response.code` being equated with an integer which isn’t how these specs work - it will be being equated with a string. It also wasn’t looking for, and banning, `response.status` being compared with an integer.

## How was it tested?
- [X] Specs
- [X] Locally
