### PR TITLE
Do not use parser version 2.5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.57.3
+- Do not use broken parser v2.5.1.1.
+
 ## v0.57.2
 - Fix `Ezcater/RspecRequireHttpStatusMatcher` cop.
 

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter"
 
-  spec.add_runtime_dependency "parser"
+  spec.add_runtime_dependency "parser", "!= 2.5.1.1"
   spec.add_runtime_dependency "rubocop", "~> 0.57.2"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.27.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.2"
+  VERSION = "0.57.3"
 end


### PR DESCRIPTION
## What did we change?

Prevent use of the broken parser v2.5.1.1.

## Why are we doing this?

The parser version is broken resulting in auto-correct breaking code. The latest rubocop patch (v0.58.1) adds the same exclusion: https://github.com/rubocop-hq/rubocop/commit/e41a2d5bd5b33cba1219e0f798397fac9b8fe543

Our apps/repos may also pick up the broken version unless we restrict it.

## How was it tested?
- [x] Specs
- [x] Locally
