### PR TITLE
Configure `Rspec/MessageExpectation` with `allow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.57.4
+- Configure `Rspec/MessageExpectation` with the `allow` style.
+
 ## v0.57.3
 - Do not use broken parser v2.5.1.1.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -68,6 +68,10 @@ RSpec/ExampleLength:
 RSpec/LetSetup:
   Enabled: false
 
+RSpec/MessageExpectation:
+  Enabled: true
+  EnforcedStyle: allow
+
 RSpec/MultipleExpectations:
   Max: 5
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.3"
+  VERSION = "0.57.4"
 end


### PR DESCRIPTION
## What did we change?
Configure `Rspec/MessageExpectation` with the `allow` style.

## Why are we doing this?
Style council decision

## How was it tested?
- [ ] Specs
- [ ] Locally
