### PR TITLE
Update to rubocop v0.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.58.0
 - Update to rubocop v0.58.1.
-- Enable `Naming/MemoizedInstanceVariableName` with optional leading
+- Enable `Naming/MemoizedInstanceVariableName` with required leading
   underscore.
 
 ## v0.57.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ezcater_rubocop
 
+## v0.58.0
+- Update to rubocop v0.58.1.
+- Enable `Naming/MemoizedInstanceVariableName` with optional leading
+  underscore.
+
 ## v0.57.4
 - Configure `Rspec/MessageExpectation` with the `allow` style.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -38,7 +38,7 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 Naming/MemoizedInstanceVariableName:
-  EnforcedStyleForLeadingUnderscores: optional
+  EnforcedStyleForLeadingUnderscores: required
 
 Naming/UncommunicativeMethodParamName:
   AllowedNames:

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -37,9 +37,8 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-# Disable this cop until configuration options are available (>= 0.58.0)
 Naming/MemoizedInstanceVariableName:
-  Enabled: false
+  EnforcedStyleForLeadingUnderscores: optional
 
 Naming/UncommunicativeMethodParamName:
   AllowedNames:

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -49,6 +49,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter"
 
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
-  spec.add_runtime_dependency "rubocop", "~> 0.57.2"
+  spec.add_runtime_dependency "rubocop", "~> 0.58.1"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.27.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.57.4"
+  VERSION = "0.58.0.rc0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.58.0.rc0"
+  VERSION = "0.58.0.rc1"
 end


### PR DESCRIPTION
## What did we change?

Updated to the latest rubocop release.

Enabled instance variable naming cop now that configuration is available.

## Why are we doing this?

To keep up with rubocop releases.

This updated was tested against:
- ezcater_kafka
- ezcater-identity
- ezcater-sms-service
- ezcater-delivery

Only ezcater-delivery had a new offense, shown here: https://github.com/ezcater/ezcater-delivery/pull/621

## How was it tested?
- [x] Specs
- [ ] Locally
