### PR TITLE
Add PreventGraphqlEnumPostfix cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.58.1
+- Add `Ezcater/PreventGraphqlEnumPostfix` cop.
+
 ## v0.58.0
 - Update to rubocop v0.58.1.
 - Enable `Naming/MemoizedInstanceVariableName` with required leading

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ the latest compatible version each time that the MAJOR.MINOR version of `rubocop
 is updated.
 
 ## Custom Cops
+1. [PreventGraphqlEnumPostfix](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/prevent_graphql_enum_postfix.rb) - Prevent use of an 'Enum' postfix when naming GraphQL Enums
 1. [PrivateAttr](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/private_attr.rb) - Require methods from the `private_attr` gem.
 1. [RailsConfiguration](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rails_configuration.rb) - Enforce use of `Rails.configuration` instead of `Rails.application.config`.
 1. [RequireGqlErrorHelpers](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb) - Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,7 @@
+Ezcater/PreventGraphqlEnumPostfix:
+  Description: "Prevent use of an 'Enum' postfix when naming GraphQL Enums"
+  Enabled: true
+
 Ezcater/PrivateAttr:
   Description: 'Require methods from the private_attr gem'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -14,6 +14,7 @@ puts "configuration from #{DEFAULT_FILES}" if RuboCop::ConfigLoader.debug?
 config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
+require "rubocop/cop/ezcater/prevent_graphql_enum_postfix"
 require "rubocop/cop/ezcater/private_attr"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/require_gql_error_helpers"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.58.0"
+  VERSION = "0.58.1"
 end

--- a/lib/rubocop/cop/ezcater/prevent_graphql_enum_postfix.rb
+++ b/lib/rubocop/cop/ezcater/prevent_graphql_enum_postfix.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # Prevent use of an 'Enum' postfix when naming GraphQL Enums
+      #
+      # @example
+      #
+      #   # good
+      #   Enums:ThisIsGood = GraphQL::EnumType.define do
+      #     name "ThisIsGood"
+      #
+      #     # Other configuration here
+      #   end
+      #
+      #   # bad
+      #   Enums:ThisIsBadEnum = GraphQL::EnumType.define do
+      #     name "ThisIsBadEnum"
+      #
+      #     # Other configuration here
+      #   end
+      class PreventGraphqlEnumPostfix < Cop
+        MSG = "The name of your Enum should not be postfixed with 'Enum'"
+
+        def_node_matcher :graphql_enum?, <<~PATTERN
+          (casgn (const nil? :Enums) $_enum_name ...)
+        PATTERN
+
+        def on_casgn(node)
+          enum_name = graphql_enum?(node)
+
+          return unless enum_name&.to_s&.end_with?("Enum")
+
+          add_offense(node, location: :name, message: MSG)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/prevent_graphql_enum_postfix_spec.rb
+++ b/spec/rubocop/cop/ezcater/prevent_graphql_enum_postfix_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::Ezcater::PreventGraphqlEnumPostfix, :config do
+  subject(:cop) { described_class.new }
+
+  let(:error_message) { described_class::MSG }
+  let(:source) do
+    <<~CODE
+      Enums::#{expected_highlight} = GraphQL::EnumType.define do
+        # other code here
+      end
+    CODE
+  end
+
+  before do
+    inspect_source(source)
+  end
+
+  context "when the name of the Enum ends in 'Enum'" do
+    let(:expected_highlight) { "ThisIsBadEnum" }
+
+    it "registers an offense" do
+      expect(cop.messages).to match_array([error_message])
+      expect(cop.highlights).to match_array([expected_highlight])
+    end
+  end
+
+  context "when the name of the Enum does not end in 'Enum'" do
+    let(:expected_highlight) { "ThisIsGood" }
+
+    it "does not regeister an offense" do
+      expect(cop.offenses).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?
Add PreventGraphqlEnumPostfix cop to prevent us from naming our Enums with an `Enum` postfix

## Why are we doing this?
GraphQL best practices: https://ezcater.atlassian.net/wiki/spaces/POL/pages/229934050/GraphQL+API+Best+Practices

## How was it tested?
- [x] Specs
- [ ] Locally
