### PR TITLE
Update to rubocop-rspec 1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ezcater_rubocop
 
+## v0.58.1
+- Update to `rubocop-rspec` v1.28.0.
+- Remove configuration for removed `FactoryBot/DynamicAttributeDefinedStatically` cop.
+
 ## v0.58.0
 - Update to rubocop v0.58.1.
 - Enable `Naming/MemoizedInstanceVariableName` with required leading

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -3,11 +3,6 @@ require: ezcater_rubocop
 AllCops:
   DisplayCopNames: true
 
-# This is a useful cop but produces some false positives and can break code:
-# https://github.com/rubocop-hq/rubocop-rspec/issues/655
-FactoryBot/DynamicAttributeDefinedStatically:
-  Enabled: false
-
 Layout/DotPosition:
   EnforcedStyle: trailing
 

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -49,6 +49,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter"
 
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
-  spec.add_runtime_dependency "rubocop", "~> 0.58.1"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.27.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.58.2"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.28.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.58.0"
+  VERSION = "0.58.1"
 end


### PR DESCRIPTION
## What did we change?

Updated the required version of rubocop-rspec.

## Why are we doing this?

Generally I've waited to bump rubocop-rspec minor versions until there was a new version of the core rubocop. But in this case, I think it might be helpful to bump rubocop-rspec to deal with FactoryBot's deprecation of static attributes.

## How was it tested?
- [x] Specs
- [ ] Locally
