### PR TITLE
Turn off the RSpec/MessageExpectation cop

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -62,10 +62,6 @@ RSpec/ExampleLength:
 RSpec/LetSetup:
   Enabled: false
 
-RSpec/MessageExpectation:
-  Enabled: true
-  EnforcedStyle: allow
-
 RSpec/MultipleExpectations:
   Max: 5
 


### PR DESCRIPTION
The Style Council decided at the [10/15 meeting](https://ezcater.atlassian.net/wiki/spaces/POL/pages/757991514/2018-10-15+Style+Council+Sync+notes) to be more permissive of this syntax.