### PR TITLE
Configure Layout/MultilineMethodCallIndentation with indented

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -3,6 +3,9 @@ require: ezcater_rubocop
 AllCops:
   DisplayCopNames: true
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 


### PR DESCRIPTION
## What did we change?

[`Layout/MultilineMethodCallIndentation`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodCallIndentation) is now configured as `indented`. This has already been turned on in ezRails since 2016 (ezcater/ez-rails#4519), but all of our other apps haven't been following the same rule.

The rule changes this:

```ruby
subscriptions = Subscription.
                where(subscription_existence_params).
                select("DISTINCT ON (subscriber_id) *").
                order(:subscriber_id, :created_at, :id).
                to_a
```

To this:

```ruby
subscriptions = Subscription.
  where(subscription_existence_params).
  select("DISTINCT ON (subscriber_id) *").
  order(:subscriber_id, :created_at, :id).
  to_a
```

## Why are we doing this?

The most recent [Style Council meeting](https://ezcater.atlassian.net/wiki/spaces/POL/pages/773292623/2018-10-22+Style+Council+Sync+notes) agreed to change this.

## How was it tested?
- [ ] Specs
- [ ] Locally
