### PR TITLE
Update `Metrics/BlockLength` to exclude `app/graphql/**/*.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.58.4
 - Update `Metrics/BlockLength` to exclude `app/graphql/**/*.rb`
+- Move `Metrics/BlockLength` exclusions for `lib/tasks/**/*.rake` and `config/environments/*.rb` into rubocop_rails.yml
 
 ## v0.58.3
 - Updated `Layout/MultilineMethodCallIndentation` to `indented`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ezcater_rubocop
 
+## v0.58.4
+- Update `Metrics/BlockLength` to exclude `app/graphql/**/*.rb`
+
 ## v0.58.3
 - Updated `Layout/MultilineMethodCallIndentation` to `indented`.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -16,9 +16,6 @@ Metrics/BlockLength:
   Exclude:
   - "*.gemspec"
   - "spec/**/*.rb"
-  - "lib/tasks/**/*.rake"
-  - "config/environments/*.rb"
-  - "app/graphql/**/*.rb"
 
 Metrics/CyclomaticComplexity:
   Enabled: false
@@ -133,4 +130,3 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
-

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -18,6 +18,7 @@ Metrics/BlockLength:
   - "spec/**/*.rb"
   - "lib/tasks/**/*.rake"
   - "config/environments/*.rb"
+  - "app/graphql/**/*.rb"
 
 Metrics/CyclomaticComplexity:
   Enabled: false

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -1,14 +1,13 @@
 inherit_from:
   - ../conf/rubocop.yml
 
-inherit_mode:
-  merge:
-    - Exclude
-
 AllCops:
   TargetRailsVersion: 5.1
 
 Metrics/BlockLength:
+  inherit_mode:
+    merge:
+      - Exclude
   Exclude:
   - "lib/tasks/**/*.rake"
   - "config/environments/*.rb"

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -1,8 +1,18 @@
 inherit_from:
   - ../conf/rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   TargetRailsVersion: 5.1
+
+Metrics/BlockLength:
+  Exclude:
+  - "lib/tasks/**/*.rake"
+  - "config/environments/*.rb"
+  - "app/graphql/**/*.rb"
 
 Rails:
   Enabled: true

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -9,9 +9,9 @@ Metrics/BlockLength:
     merge:
       - Exclude
   Exclude:
-  - "lib/tasks/**/*.rake"
-  - "config/environments/*.rb"
   - "app/graphql/**/*.rb"
+  - "config/environments/*.rb"
+  - "lib/tasks/**/*.rake"
 
 Rails:
   Enabled: true

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.58.3"
+  VERSION = "0.58.4"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.58.4"
+  VERSION = "0.58.3"
 end


### PR DESCRIPTION
## What did we change?
Update `Metrics/BlockLength` to exclude `app/graphql/**/*.rb`

## Why are we doing this?
The style council determined this rule isn't helpful for graphql types, given that graphql types are defined within a block. See https://ezcater.atlassian.net/wiki/spaces/POL/pages/786334408/2018-11-05+Style+Council+Sync+notes

## How was it tested?
- [x] Specs
- [x] Locally
