### PR TITLE
Disable the Style/NegatedIf cop

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -94,6 +94,9 @@ Style/Documentation:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/NegatedIf:
+  Enabled: false
+
 # This cop does not yet support a style to prevent underscores
 Style/NumericLiterals:
   Enabled: false


### PR DESCRIPTION
## What did we change?

Disables the [`Style/NegatedIf`](https://www.rubydoc.info/gems/rubocop/0.43.0/RuboCop/Cop/Style/NegatedIf) cop.

## Why are we doing this?

Style Council has voted to allow developers to choose the right tool for the job, rather than enforcing 1 way all the time.

## How was it tested?
- [ ] Specs
- [ ] Locally
