### PR TITLE
Update Rubocop dependency to v0.61.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ezcater_rubocop
 
 ## Unreleased
+- Update to `rubocop` v0.61.1.
+- Update to `rubocop-rspec` v1.30.1
 
 ## v0.59.0
 - Disable `Style/NegatedIf`.

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
-  spec.add_runtime_dependency "rubocop", "~> 0.58.2"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.28.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.61.1"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 1.30.1"
 end

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -24,8 +24,8 @@ module RuboCop
       #   end
 
       class RspecDotNotSelfDot < Cop
-        SELF_DOT_REGEXP = /["']self\./
-        COLON_COLON_REGEXP = /["'](\:\:)/
+        SELF_DOT_REGEXP = /["']self\./.freeze
+        COLON_COLON_REGEXP = /["'](\:\:)/.freeze
 
         SELF_DOT_MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'
         COLON_COLON_MSG = 'Use ".<class method>" instead of "::<class method>" for example group description.'

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -29,6 +29,7 @@ module RuboCop
 
         def on_send(node)
           return unless nested_access_match(node) && !assignment?(node)
+
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)

--- a/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireFeatureFlagMock, :config do
   end
 
   it "accepts usage of the mock_feature_flag helper with options" do
-    inspect_source([
-                     "user = create(:user)",
-                     "mock_feature_flag(\"MyFeatureFlag\", { user: user }, true)",
-                   ])
+    inspect_source(<<-RUBY)
+      user = create(:user)
+      mock_feature_flag(\"MyFeatureFlag\", { user: user }, true)
+    RUBY
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireHttpStatusMatcher do
   it "registers an offence when attempting to assert directly on the status" do
     inspect_source("expect(response.status).to eq 400")
     expect(cop.messages).to match_array(["Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`",])
+      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`"])
   end
 
   it "registers an offence when attempting to assert directly on the code" do
     inspect_source("expect(response.code).to eq \"400\"")
     expect(cop.messages).to match_array(["Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq \"400\"`",])
+      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq \"400\"`"])
   end
 end


### PR DESCRIPTION
## What did we change?

Updates our dependencies on `rubocop` and `rubocop-rspec` to the latest versions.

## Why are we doing this?

I screwed up when bumping this gem to `v0.59.0` in eef26ea994f5684764e10d8ae2fddd7a6b85c6a8, neglecting the [Versioning](https://github.com/ezcater/ezcater_rubocop/tree/eef26ea994f5684764e10d8ae2fddd7a6b85c6a8#versioning) documentation in the `README`.

After talking with @tjwp, rather than `yank`ing that gem release and releasing again as `v0.58.5`, I'm going to get this out as `v0.61.0`.

## How was it tested?
- [x] Specs
- [x] Locally
