### PR TITLE
Set Layout/IndentHash and Layout/IndentArray to consistent style

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -3,6 +3,12 @@ require: ezcater_rubocop
 AllCops:
   DisplayCopNames: true
 
+Layout/IndentHash:
+  EnforcedStyle: consistent
+
+Layout/IndentArray:
+  EnforcedStyle: consistent
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 


### PR DESCRIPTION
## What did we change?

Sets the [`Layout/IndentHash`](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindenthash) and [`Layout/IndentArray`](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentarray) cops to enforce `consistent` style.

## Why are we doing this?

The [Style Council decided](https://ezcater.atlassian.net/wiki/spaces/POL/pages/808649364/2018-11-26+Style+Council+Sync+notes) to set `Layout/IndentHash` to `consistent`. Per [a comment](https://ezcater.atlassian.net/wiki/spaces/POL/pages/808649364/2018-11-26+Style+Council+Sync+notes?focusedCommentId=809598977#comment-809598977), for consistency(!), the same is applied to `Layout/IndentArray`.

## How was it tested?
- [ ] Specs
- [x] Locally
