### PR TITLE
Circle installs bundler 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             chmod +x ./cc-test-reporter
 
       # Bundle install dependencies
-      - run: gem install bundler --no-document
+      - run: gem install bundler --no-document -v 1.15.0
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - run: bundle clean --force
 


### PR DESCRIPTION
## What did we change?

Fix CircleCI builds for this gem by installing the required "1.15.x" version of bundler vs. the latest in our CI environment configuration.

## Why are we doing this?

Avoid/fix CI dependency failures due to Bundle 2.x issues by not installing the latest available Bundler in CI by default.

## How was it tested?
- [x] Specs
- [ ] Locally
