### PR TITLE
Release v0.61.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ezcater_rubocop
 
+## v0.61.1
+- `Layout/IndentHash` enforces consistent style
+- `Layout/IndentArray` enforces consistent style
+
 ## v0.61.0
 - Update to `rubocop` v0.61.1.
 - Update to `rubocop-rspec` v1.30.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ezcater_rubocop
 
+# Versioning
+
+NB: This gem is versioned based on the `MAJOR`.`MINOR` version of rubocop. The first release of the
+ezcater_rubocop gem was `v0.49.0`.
+
 ## v0.61.1
 - `Layout/IndentHash` enforces consistent style
 - `Layout/IndentArray` enforces consistent style

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.61.0"
+  VERSION = "0.61.1"
 end


### PR DESCRIPTION
## What did we change?

* Update release notes in `CHANGELOG`
* Bump gem version to v. `0.61.1`
* Add Versioning section to `CHANGELOG` 

## Why are we doing this?

Release unpublished style rule changes.  Add versioning note to `CHANGELOG` to aid in versioning releases and reading the notes.

## How was it tested?
- [x] Specs
- [ ] Locally
