### PR TITLE
Release v0.61.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 NB: This gem is versioned based on the `MAJOR`.`MINOR` version of rubocop. The first release of the
 ezcater_rubocop gem was `v0.49.0`.
 
+## v0.61.2
+- Delete `Ezcater/PrivateAttr`
+
 ## v0.61.1
 - `Layout/IndentHash` enforces consistent style
 - `Layout/IndentArray` enforces consistent style

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.61.1"
+  VERSION = "0.61.2"
 end


### PR DESCRIPTION
## What did we change?
We've bumped the gem version to 0.61.2

## Why are we doing this?
It'd be nice to have this version out in the wild. We have some unpublished rule changes.
