### PR TITLE
Update language around versioning, bump v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 # Versioning
 
-NB: This gem is versioned based on the `MAJOR`.`MINOR` version of rubocop. The first release of the
+ezCater is moving onto its own [Semantic Versioning](https://semver.org/) scheme starting with v1.0.0. All version bumps moving forward should increment using `MAJOR.MINOR.PATCH` based on changes.
+
+Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the
 ezcater_rubocop gem was `v0.49.0`.
+
+## v1.0.0
+
+- Begin using Semantic Versioning
+- Delete `Ezcater/PrivateAttr`
 
 ## v0.61.1
 - `Layout/IndentHash` enforces consistent style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Versioning
 
-ezCater is moving onto its own [Semantic Versioning](https://semver.org/) scheme starting with v1.0.0. All version bumps moving forward should increment using `MAJOR.MINOR.PATCH` based on changes.
+This gem is moving onto its own [Semantic Versioning](https://semver.org/) scheme starting with v1.0.0. All version bumps moving forward should increment using `MAJOR.MINOR.PATCH` based on changes.
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the
 ezcater_rubocop gem was `v0.49.0`.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ running rubocop.
 
 ## Versioning
 
-ezCater is using [Semantic Versioning](https://semver.org/). All version bumps should increment using `MAJOR.MINOR.PATCH` based on changes.
+This gem is using [Semantic Versioning](https://semver.org/). All version bumps should increment using `MAJOR.MINOR.PATCH` based on changes.
 
 ## Custom Cops
 

--- a/README.md
+++ b/README.md
@@ -70,17 +70,7 @@ running rubocop.
 
 ## Versioning
 
-This gem is versioned based on the MAJOR.MINOR version of `rubocop`. The first
-release of the `ezcater_rubocop` gem was v0.49.0.
-
-The patch version for this gem does _not_ correspond to the patch version of
-`rubocop`. The patch version for this gem will change any time that one of its
-configurations is modified _or_ its dependency on `rubocop` is changed to require
-a different patch version.
-
-This gem also includes a dependency on `rubocop-rspec` that will be updated to
-the latest compatible version each time that the MAJOR.MINOR version of `rubocop`
-is updated.
+ezCater is using [Semantic Versioning](https://semver.org/). All version bumps should increment using `MAJOR.MINOR.PATCH` based on changes.
 
 ## Custom Cops
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "0.61.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
## What did we change?
Bumping to v1.0.0 to start taking advantage of semantic versioning.

## Why are we doing this?
Easier to maintain our own appropriate versioning. Discussion in #62 for reference. 

## How was it tested?
- [ ] Specs
- [ ] Locally
