### PR TITLE
Disable the Rails/HasAndBelongsToMany cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the
 ezcater_rubocop gem was `v0.49.0`.
 
+## Unreleased
+
+- Disable `Rails/HasAndBelongsToMany` cop.
+
 ## v1.0.0
 
 - Begin using Semantic Versioning

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -19,6 +19,9 @@ Rails:
 Rails/FilePath:
   Enabled: false
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 Rails/RelativeDateConstant:
   # Auto-correct is broken for this cops in some cases. It replaces the
   # constant but does not update references to it.


### PR DESCRIPTION
## What did we change?

Disable the `Rails/HasAndBelongsToMany` cop.

## Why are we doing this?

Rails' own [guides](https://guides.rubyonrails.org/association_basics.html#choosing-between-has-many-through-and-has-and-belongs-to-many) still recommend `has_and_belongs_to_many` in simple scenarios.

## How was it tested?
- [x] Specs
- [x] Locally
