### PR TITLE
Exclude default bootsnap cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the
 ezcater_rubocop gem was `v0.49.0`.
 
-## v1.0.1
+## v1.0.2 (unreleased)
+- Exclude bootsnap cache directory (`tmp/cache`).
 
+## v1.0.1
 - Disable `Rails/HasAndBelongsToMany` cop.
 - Disable `Style/DoubleNegation` cop.
 
 ## v1.0.0
-
 - Begin using Semantic Versioning
 - Delete `Ezcater/PrivateAttr`
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -1,8 +1,14 @@
 inherit_from:
   - ../conf/rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   TargetRailsVersion: 5.1
+  Exclude:
+    - tmp/cache/**/*
 
 Metrics/BlockLength:
   inherit_mode:


### PR DESCRIPTION
## What did we change?

Added the default directory (`tmp/cache`) used by bootsnap to the list of files that are excluded for all cops.

## Why are we doing this?

Excluding the bootsnap cache cuts the time to run rubocop in half for me with a relatively empty, new app.

The `inherit_mode` configuration is added so that this addition to the list of excluded files does not override the default list of excluded files.

I found that setting this `inherit_mode` under `AllCops` was not respected.

## How was it tested?
- [x] Specs
- [ ] Locally
