### PR TITLE
Add CODEOWNERS based on the new Ruby Style Group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @agrobbin @aprescott @tjwp


### PR DESCRIPTION
This repo is public, but I think we still want this set up with `CODEOWNERS`.