### PR TITLE
Add a cop to catch unwanted Rails.env use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the
 ezcater_rubocop gem was `v0.49.0`.
 
+## Unreleased
+
+- Add `Ezcater/RailsEnv` cop.
+
 ## v1.0.2
 - Exclude bootsnap cache directory (`tmp/cache`).
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,14 @@ Ezcater/RailsConfiguration:
   Description: 'Enforce the use of `Rails.configuration` instead of `Rails.application.config`.'
   Enabled: true
 
+Ezcater/RailsEnv:
+  Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of `Rails.env` checks.'
+  Enabled: true
+  Exclude:
+    - "config/**/*"
+    - "spec/rails_helper.rb"
+    - "db/**/*"
+
 Ezcater/RspecDotNotSelfDot:
   Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -15,6 +15,7 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/rails_configuration"
+require "rubocop/cop/ezcater/rails_env"
 require "rubocop/cop/ezcater/require_gql_error_helpers"
 require "rubocop/cop/ezcater/rspec_match_ordered_array"
 require "rubocop/cop/ezcater/rspec_require_browser_mock"

--- a/lib/rubocop/cop/ezcater/rails_env.rb
+++ b/lib/rubocop/cop/ezcater/rails_env.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # Use the `Rails.configuration.x` namespace for configuration backed by
+      # environment variables, rather than inspecting `Rails.env` directly.
+      # Centralizing application configuration helps avoid scattering it
+      # throughout the codebase, and avoids coarse environment grouping under
+      # a single RAILS_ENV var. See https://ezcater.atlassian.net/wiki/x/ZIChNg.
+      #
+      # @example
+      #
+      #   # good
+      #   enforce_foo! if Rails.configuration.x.foo_enforced
+      #
+      #   # bad
+      #   foo! if Rails.env.production?
+
+      class RailsEnv < Cop
+        MSG = <<~END_MESSAGE
+          Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that
+          configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg
+        END_MESSAGE
+
+        def_node_matcher "rails_env", <<-PATTERN
+          (send (send (const _ :Rails) :env) _ ...)
+        PATTERN
+
+        def on_send(node)
+          rails_env(node) do
+            add_offense(node, location: :expression, message: MSG)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/rails_env_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_env_spec.rb
@@ -1,0 +1,48 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::RailsEnv, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "allows plain Rails.env references" do
+    source = "Rails.env"
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+    expect(cop.highlights).to be_empty
+  end
+
+  it "allows Rails.env for interpolated string values" do
+    source = %q(foo("#{Rails.env}-bar")) # rubocop:disable Lint/InterpolationCheck
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+    expect(cop.highlights).to be_empty
+  end
+
+  it "blocks specific env checks via Rails.env" do
+    source = "Rails.env.development?"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array([source])
+    expect(cop.messages).to match_array([described_class::MSG])
+
+    %w(production staging foo).each do |env_str|
+      inspect_source("Rails.env.#{env_str}?")
+      expect(cop.offenses).not_to be_empty
+    end
+  end
+
+  it "blocks equality checks" do
+    source = "Rails.env == 'development'"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array([source])
+  end
+
+  it "does not support autocorrect" do
+    source = "Rails.env.development?"
+    inspect_source(source)
+    expect(cop.highlights).to match_array([source])
+    expect(cop.messages).to match_array([described_class::MSG])
+    expect(autocorrect_source(source)).to eq(source)
+  end
+end


### PR DESCRIPTION
## What did we change?

Added a cop to catch `Rails.env` references outside of `config/`.

## Why are we doing this?

Outside of `config/`, we want to avoid inspecting `Rails.env` to define
behavior. A couple of exceptions:

* Using `Rails.env`'s value for metadata-like purposes is permitted. For example, if some logging includes `Rails.env`, that's allowed.
* `db/` is ignored to allow dev-only migrations, which is a common existing pattern.

## How was it tested?
- [x] Specs
- [x] Locally
