### PR TITLE
Lint against ENV references outside of config/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ezcater_rubocop gem was `v0.49.0`.
 ## Unreleased
 
 - Add `Ezcater/RailsEnv` cop.
+- Add `Ezcater/DirectEnvCheck` cop.
 
 ## v1.0.2
 - Exclude bootsnap cache directory (`tmp/cache`).

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -46,3 +46,20 @@ Rails/UnknownEnv:
     - test
     - staging
     - production
+
+Ezcater/RailsEnv:
+  Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `Rails.env`.'
+  Enabled: true
+  Exclude:
+    - "config/**/*"
+    - "spec/rails_helper.rb"
+    - "db/**/*"
+
+Ezcater/DirectEnvCheck:
+  Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `ENV`.'
+  Enabled: true
+  Exclude:
+    - "bin/**/*"
+    - "config/**/*"
+    - "spec/rails_helper.rb"
+    - "db/**/*"

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,9 +3,18 @@ Ezcater/RailsConfiguration:
   Enabled: true
 
 Ezcater/RailsEnv:
-  Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of `Rails.env` checks.'
+  Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `Rails.env`.'
   Enabled: true
   Exclude:
+    - "config/**/*"
+    - "spec/rails_helper.rb"
+    - "db/**/*"
+
+Ezcater/DirectEnvCheck:
+  Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `ENV`.'
+  Enabled: true
+  Exclude:
+    - "bin/**/*"
     - "config/**/*"
     - "spec/rails_helper.rb"
     - "db/**/*"

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,20 +4,11 @@ Ezcater/RailsConfiguration:
 
 Ezcater/RailsEnv:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `Rails.env`.'
-  Enabled: true
-  Exclude:
-    - "config/**/*"
-    - "spec/rails_helper.rb"
-    - "db/**/*"
+  Enabled: false
 
 Ezcater/DirectEnvCheck:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `ENV`.'
-  Enabled: true
-  Exclude:
-    - "bin/**/*"
-    - "config/**/*"
-    - "spec/rails_helper.rb"
-    - "db/**/*"
+  Enabled: false
 
 Ezcater/RspecDotNotSelfDot:
   Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -14,6 +14,7 @@ puts "configuration from #{DEFAULT_FILES}" if RuboCop::ConfigLoader.debug?
 config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
+require "rubocop/cop/ezcater/direct_env_check"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rails_env"
 require "rubocop/cop/ezcater/require_gql_error_helpers"

--- a/lib/rubocop/cop/ezcater/direct_env_check.rb
+++ b/lib/rubocop/cop/ezcater/direct_env_check.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # Use the `Rails.configuration.x` namespace for configuration backed by
+      # environment variables, rather than inspecting `ENV` directly.
+      #
+      # Restricting environment variables references to be within application
+      # configuration makes it more obvious which env vars an application relies
+      # upon. See https://ezcater.atlassian.net/wiki/x/ZIChNg.
+      #
+      # @example
+      #
+      #   # good
+      #   enforce_foo! if Rails.configuration.x.foo_enforced
+      #
+      #   # bad
+      #   enforce_foo! if ENV["FOO_ENFORCED"] == "true"
+      #
+      class DirectEnvCheck < Cop
+        MSG = <<~END_MESSAGE.split("\n").join(" ")
+          Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `ENV`. Restricting
+          environment variables references to be within application configuration makes it more obvious which env vars
+          an application relies upon. https://ezcater.atlassian.net/wiki/x/ZIChNg
+        END_MESSAGE
+
+        def_node_matcher "env_ref", <<-PATTERN
+          (const _ :ENV)
+        PATTERN
+
+        def on_const(node)
+          env_ref(node) do
+            add_offense(node, location: :expression, message: MSG)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ezcater/rails_env.rb
+++ b/lib/rubocop/cop/ezcater/rails_env.rb
@@ -5,9 +5,10 @@ module RuboCop
     module Ezcater
       # Use the `Rails.configuration.x` namespace for configuration backed by
       # environment variables, rather than inspecting `Rails.env` directly.
+      #
       # Centralizing application configuration helps avoid scattering it
       # throughout the codebase, and avoids coarse environment grouping under
-      # a single RAILS_ENV var. See https://ezcater.atlassian.net/wiki/x/ZIChNg.
+      # a single env var. See https://ezcater.atlassian.net/wiki/x/ZIChNg.
       #
       # @example
       #
@@ -15,10 +16,13 @@ module RuboCop
       #   enforce_foo! if Rails.configuration.x.foo_enforced
       #
       #   # bad
-      #   foo! if Rails.env.production?
-
+      #   enforce_foo! if Rails.env.production?
+      #
+      #   # bad
+      #   enforce_foo! if ENV["RAILS_ENV"] == "production"
+      #
       class RailsEnv < Cop
-        MSG = <<~END_MESSAGE
+        MSG = <<~END_MESSAGE.split("\n").join(" ")
           Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that
           configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg
         END_MESSAGE

--- a/spec/rubocop/cop/ezcater/direct_env_check_spec.rb
+++ b/spec/rubocop/cop/ezcater/direct_env_check_spec.rb
@@ -1,0 +1,38 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::DirectEnvCheck, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "blocks plain ENV references" do
+    source = "ENV"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["ENV"])
+    expect(cop.messages).to match_array([described_class::MSG])
+  end
+
+  it "blocks ENV for interpolated string values" do
+    source = %q(foo("#{ENV}-bar")) # rubocop:disable Lint/InterpolationCheck
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["ENV"])
+    expect(cop.messages).to match_array([described_class::MSG])
+  end
+
+  it "blocks key retrieval" do
+    source = 'ENV["FOO"]'
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["ENV"])
+    expect(cop.messages).to match_array([described_class::MSG])
+  end
+
+  it "blocks key retrieval with equality checks" do
+    source = 'ENV["FOO"] == "true"'
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["ENV"])
+    expect(cop.messages).to match_array([described_class::MSG])
+  end
+end


### PR DESCRIPTION
## What did we change?

Similar to the `RailsEnv` cop (#83), but for `ENV` references.

## Why are we doing this?

To help us follow the decided env var best practices.

## How was it tested?
- [x] Specs
- [x] Locally
