### PR TITLE
Ignore lib/tasks/ for Ezcater/RailsEnv and Ezcater/DirectEnvCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of R
 
 ## Unreleased
 
-- ...
+- Exclude `lib/tasks/` for `Ezcater/RailsEnv` and `Ezcater/DirectEnvCheck`.
 
 ## v1.1.0
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -54,6 +54,8 @@ Ezcater/RailsEnv:
     - "config/**/*"
     - "spec/rails_helper.rb"
     - "db/**/*"
+    - "lib/tasks/**/*"
+    - "spec/lib/tasks/**/*"
 
 Ezcater/DirectEnvCheck:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `ENV`.'
@@ -63,3 +65,5 @@ Ezcater/DirectEnvCheck:
     - "config/**/*"
     - "spec/rails_helper.rb"
     - "db/**/*"
+    - "lib/tasks/**/*"
+    - "spec/lib/tasks/**/*"


### PR DESCRIPTION
## What did we change?

As in the title.

## Why are we doing this?

Tasks frequently use `ENV`. Since tasks are relatively small in scope and effect, so allowing `ENV` avoids excessive config definition. For consistency, `Rails.env` is permitted for the same reason (e.g., tasks that abort in non-dev environments).

## How was it tested?
- [ ] Specs
- [ ] Locally
