### PR TITLE
Add a cop to detect AR::Base.connection.execute in Rails migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of R
 
 ## Unreleased
 
-- ...
+- Add `Ezcater/RailsTopLevelSqlExecute` to replace `ActiveRecord::Base.connection.execute` with `execute` in `db/migrate/`.
 
 ## v1.1.1
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -47,6 +47,12 @@ Rails/UnknownEnv:
     - staging
     - production
 
+Ezcater/RailsTopLevelSqlExecute:
+  Description: 'Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations.'
+  Enabled: true
+  Include:
+    - "db/migrate/**/*"
+
 Ezcater/RailsEnv:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `Rails.env`.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -17,6 +17,7 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 require "rubocop/cop/ezcater/direct_env_check"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rails_env"
+require "rubocop/cop/ezcater/rails_top_level_sql_execute"
 require "rubocop/cop/ezcater/require_gql_error_helpers"
 require "rubocop/cop/ezcater/rspec_match_ordered_array"
 require "rubocop/cop/ezcater/rspec_require_browser_mock"

--- a/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
+++ b/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations. The latter is redundant and
+      # can bypass migration safety checks.
+      #
+      # @example
+      #
+      #   # good
+      #   execute("...")
+      #
+      #   # bad
+      #   ActiveRecord::Base.connection.execute("...")
+      #
+      class RailsTopLevelSqlExecute < Cop
+        MSG = <<~END_MESSAGE.split("\n").join(" ")
+          Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations. The latter is
+          redundant and can bypass safety checks.
+        END_MESSAGE
+
+        def_node_matcher "ar_connection_execute", <<-PATTERN
+          (send (send (const (const _ :ActiveRecord) :Base) :connection) :execute _)
+        PATTERN
+
+        def on_send(node)
+          ar_connection_execute(node) do
+            add_offense(node, location: :expression, message: MSG)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            range = Parser::Source::Range.new(
+              node.source_range.source_buffer,
+              node.source_range.begin_pos,
+              node.source_range.end_pos
+            )
+
+            corrector.replace(range, "execute(#{node.last_argument.source})")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/rails_top_level_sql_execute_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_top_level_sql_execute_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::RailsTopLevelSqlExecute do
+  subject(:cop) { described_class.new }
+
+  let(:msgs) { [described_class::MSG] }
+
+  it "accepts `execute`" do
+    source = "execute('SELECT * FROM foo')"
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it "detects `ActiveRecord::Base.connection.execute`" do
+    source = "ActiveRecord::Base.connection.execute('SELECT * FROM foo')"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array([source])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "detects `ActiveRecord::Base.connection.execute` with non-string arguments" do
+    source = "ActiveRecord::Base.connection.execute(foo_bar)"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array([source])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "supports autocorrect" do
+    source = "ActiveRecord::Base.connection.execute('SELECT * FROM foo')"
+    inspect_source(source)
+    expect(cop.highlights).to match_array([source])
+    expect(cop.messages).to match_array(msgs)
+    expect(autocorrect_source(source)).to eq("execute('SELECT * FROM foo')")
+  end
+end


### PR DESCRIPTION
## What did we change?

Added a cop to catch instances of `ActiveRecord::Base.connection.execute` in migrations.

## Why are we doing this?

A migration can run SQL directly using `ActiveRecord::Base.connection.execute`, but not only is this redundant it removes strong_migrations' ability to detect unsafe migrations, meaning there's no check that `safety_assured` is in use. This cop should push us to using `execute` directly.

## How was it tested?
- [x] Specs
- [x] Locally
