### PR TITLE
Add a cop to require snake_case fields in graphQL definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of R
 ## Unreleased
 
 - ...
+- Add `Ezcater/GraphqlFieldsNaming` cop.
 
 ## v1.2.0
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This gem is using [Semantic Versioning](https://semver.org/). All version bumps 
 1. [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforce use of `mock_feature_flag` helper instead of mocking `FeatureFlag.is_active?` directly.
 1. [RspecRequireHttpStatusMatcher](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb) - Use the HTTP status code matcher, like `expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq 400`
 1. [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) - Recommend `dig` for deeply nested access.
+1. [GraphqlFieldsNaming](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/graphql_fields_naming.rb) - Enforce the configured style when naming graphQL fields and arguments.
 
 ## Development
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,12 @@
+Ezcater/GraphqlFieldsNaming:
+  EnforcedStyle: snake_case
+  Enabled: true
+  SupportedStyles:
+    - snake_case
+    - camelCase
+  Include:
+    - 'app/graphql/**/*.rb'
+
 Ezcater/RailsConfiguration:
   Description: 'Enforce the use of `Rails.configuration` instead of `Rails.application.config`.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -15,6 +15,7 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/direct_env_check"
+require "rubocop/cop/ezcater/graphql_fields_naming"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rails_env"
 require "rubocop/cop/ezcater/rails_top_level_sql_execute"

--- a/lib/rubocop/cop/ezcater/graphql_fields_naming.rb
+++ b/lib/rubocop/cop/ezcater/graphql_fields_naming.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # This cop makes sure that GraphQL fields & arguments match the supported style
+      # https://git.io/JeofW
+      #
+      # The cop also ignores when users provide a :camelize option, because
+      # the user is manually requesting to override the value
+      #
+      # @example
+      #   # bad
+      #   field :fooBar, ID, null: false
+      #   argument :barBaz, ID, required: true
+      #
+      #   # good
+      #   field :foo_bar, ID, null: true
+      #   field :foo_bar, ID, null: true do
+      #     argument :bar_baz, ID, required: true
+      #   end
+      #
+      #   field :fooBar, ID, null: true, camelize: true
+      #
+      class GraphqlFieldsNaming < Cop
+        include ConfigurableNaming
+
+        MSG = "Use %<style>s for GraphQL fields & arguments names. " \
+              "See https://git.io/JeofW for our guide. " \
+              "This can be overridden with camelize."
+        FIELD_ADDING_METHODS = %i(field argument).freeze
+        PROCESSABLE_TYPES = %i(sym string).freeze
+
+        def on_send(node)
+          method = method_name(node)
+          first_arg = node.first_argument
+
+          return unless FIELD_ADDING_METHODS.include? method
+          return unless PROCESSABLE_TYPES.include?(first_arg&.type)
+
+          return if includes_camelize?(node)
+
+          check_name(node, first_arg.value, node.first_argument.loc.expression)
+        end
+
+        alias on_super on_send
+        alias on_yield on_send
+
+        private
+
+        def includes_camelize?(node)
+          results = []
+          node.last_argument.each_child_node { |arg| results << args_include_camelize?(arg) }
+          results.any?
+        end
+
+        def args_include_camelize?(arg_pair)
+          key_node = arg_pair.key
+          _value_node = arg_pair.value
+
+          key_node.value.match?(/camelize/)
+        end
+
+        def method_name(node)
+          node.children[1]
+        end
+
+        def message(style)
+          format(MSG, style: style)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/graphql_fields_naming_spec.rb
+++ b/spec/rubocop/cop/ezcater/graphql_fields_naming_spec.rb
@@ -1,0 +1,137 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::GraphqlFieldsNaming, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) do
+    {
+      "EnforcedStyle" => "snake_case",
+      "SupportedStyles" => %w(snake_case camelCase),
+      "Include" => ["*"] # allow all during specs
+    }
+  end
+
+  let(:err_msg) { format(described_class::MSG, style: "snake_case") }
+
+  context "when value is the enforced style" do
+    let(:good_field_name) { :test_name }
+
+    context "when field is given as a regular method call" do
+      it "does not give any offense" do
+        source = "field :#{good_field_name}"
+
+        inspect_source(source)
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context "when field is given as a block" do
+      it "does not give any offense" do
+        source = <<~TEXT
+          field :#{good_field_name}, ID, null: true do
+            argument :test, Boolean
+          end
+        TEXT
+        inspect_source(source)
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context "when an argument is given" do
+      it "does not give any offense" do
+        source = "argument :#{good_field_name}"
+
+        inspect_source(source)
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  context "when value is the incorrect style" do
+    let(:bad_field_name) { :testName }
+
+    context "when field is given as a regular method call" do
+      it "warns the user to use the preferred style" do
+        source = "field :#{bad_field_name}"
+
+        inspect_source(source)
+
+        expect(cop.messages).to match_array [err_msg]
+      end
+    end
+
+    context "when field is given as a block" do
+      it "warns the user to use the preferred style" do
+        source = <<~TEXT
+          field :#{bad_field_name}, ID, null: true do
+            argument :test, Boolean
+          end
+        TEXT
+        inspect_source(source)
+
+        expect(cop.messages).to match_array [err_msg]
+      end
+    end
+
+    context "when an argument is given" do
+      it "warns the user to use the preferred style" do
+        source = "argument :#{bad_field_name}"
+
+        inspect_source(source)
+
+        expect(cop.messages).to match_array [err_msg]
+      end
+    end
+
+    context "when the user manually requested to camelize: the field" do
+      it "does not register an offense" do
+        source = <<~TEXT
+          field :#{bad_field_name}, ID, null: true, camelize: false do
+            argument :test, Boolean
+          end
+        TEXT
+        inspect_source(source)
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  context "when the field is defined from a different source" do
+    it "does not try to lint the line" do
+      source = <<~TEXT
+        ['source'].each do |type|
+          method_name = "type_url"
+          field(method_name.camelize(:lower), String, null: true)
+        end
+      TEXT
+      inspect_source(source)
+
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context "when the method call is not a GraphQL definitions" do
+    it "does not try to lint the line" do
+      source = <<~TEXT
+        object.payments.order(order_by.field => order_by.direction)
+      TEXT
+      inspect_source(source)
+
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context "when method call does not create a field or argument" do
+    it "does not try to lint the line" do
+      source = "description('Too Cool For School')"
+      inspect_source(source)
+
+      expect(cop.offenses).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?
* Add a cop so we can follow our style guide seen here: https://git.io/JeofW.
  * the enforced style will be `:snake_case`
  * Largely inspired by the [method_name cop](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/naming/method_name.rb)

## Why are we doing this?
* Enforce Style GraphQL
* My real motivation is this: https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#breaking-changes-6
  * When attempting to update the gem, many fields broke because the resolver method was not defined.
  * Because `snake_case` is idiomatic in ruby especially for methods, it made sense to enforce this to hopefully make it easier to port over and add methods

## NOTE
* A consequence of this PR will be to regenerate the todo file (at least in ezRails)
  * via `rubocop --auto-gen-config --exclude-limit 10000`
  * This allows us some time to go and clean up the field names because I didn't want to blindly snake case things and break schemas 😃
  

## PICS:
(taken on https://github.com/ezcater/ezcater_rubocop/pull/89/commits/7684ae69fe0de164cb3d882716ae0949b22f331c)
<img width="1377" alt="Screen Shot 2019-11-15 at 11 57 13 AM" src="https://user-images.githubusercontent.com/2018474/68960918-2464c600-079f-11ea-8e9f-b668c285281b.png">


## How was it tested?
- [x] Specs
- [x] Locally

```ruby
# manually test by updating gem source
gem "ezcater_rubocop", require: false, :path => '~/dev/ezcater/ezcater_rubocop/'
```

```bash
# in your favorite console
$ rubocop -d

# add the failed cases from above to specs
```