### PR TITLE
Detect Timeout.timeout in the expected cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## Unreleased
+- Correct a matching syntax issue with `Ezcater/RubyTimeout` so that it applies in the expected cases.
+
 ## v1.4.0
 - Add `Ezcater/RubyTimeout` cop.
 

--- a/lib/rubocop/cop/ezcater/ruby_timeout.rb
+++ b/lib/rubocop/cop/ezcater/ruby_timeout.rb
@@ -25,7 +25,7 @@ module RuboCop
         END_MESSAGE
 
         def_node_matcher "timeout", <<-PATTERN
-          (send (const _ :Timeout) :timeout)
+          (send (const _ :Timeout) :timeout ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/ezcater/ruby_timeout_spec.rb
+++ b/spec/rubocop/cop/ezcater/ruby_timeout_spec.rb
@@ -5,7 +5,39 @@ RSpec.describe RuboCop::Cop::Ezcater::RubyTimeout do
 
   let(:msgs) { [described_class::MSG] }
 
-  it "detects `Timeout.timeout`" do
+  it "detects `Timeout.timeout(n)`" do
+    source = "Timeout.timeout(n) { foo }"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["Timeout.timeout(n)"])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "detects `::Timeout.timeout(n)`" do
+    source = "::Timeout.timeout(n) { foo }"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["::Timeout.timeout(n)"])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "detects `Timeout.timeout(n, a)`" do
+    source = "Timeout.timeout(n, a) { foo }"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["Timeout.timeout(n, a)"])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "detects `Timeout.timeout(n, a, b)`" do
+    source = "Timeout.timeout(n, a, b) { foo }"
+    inspect_source(source)
+    expect(cop.offenses).not_to be_empty
+    expect(cop.highlights).to match_array(["Timeout.timeout(n, a, b)"])
+    expect(cop.messages).to match_array(msgs)
+  end
+
+  it "detects plain `Timeout.timeout` calls" do
     source = "Timeout.timeout"
     inspect_source(source)
     expect(cop.offenses).not_to be_empty


### PR DESCRIPTION
## What did we change?

As in the title.

## Why are we doing this?

`(send (const _ :Foo) :bar)` matches `Foo.bar` but not `Foo.bar(...)`.

## How was it tested?
- [x] Specs
- [x] Locally
