### PR TITLE
DEL-379 Adds cop for adding comment for migration best practices documentation to migration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## v2.1.0
+- Add `Ezcater/MigrationDocumentation` cop.
+
 ## v2.0.0
 - Update to `rubocop` v0.81.0, `rubocop-rspec` v1.38.1 and `rubocop-rails` v2.5.2.
 - This is being released as a major update because cops have been renamed so this is unlikely to be

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This gem is using [Semantic Versioning](https://semver.org/). All version bumps 
 1. [RspecRequireHttpStatusMatcher](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb) - Use the HTTP status code matcher, like `expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq 400`
 1. [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/style_dig.rb) - Recommend `dig` for deeply nested access.
 1. [GraphqlFieldsNaming](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/graphql_fields_naming.rb) - Enforce the configured style when naming graphQL fields and arguments.
+1. [MigrationDocumentation](https://github.com/ezcater/ezcater_rubocop/blob/master/lib/rubocop/cop/ezcater/migration_documentation.rb) - Enforce adding a comment with the link to documenation on ezCater migration best practices on each migration file
 
 ## Development
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -55,3 +55,9 @@ Ezcater/StyleDig:
 Ezcater/RubyTimeout:
   Description: 'Disallow use of `Timeout.timeout` because it is unsafe and can cause unexpected behavior.'
   Enabled: true
+
+Ezcater/MigrationDocumentation:
+  Description: 'Enforce the comment with link to migration best practices on migration files'
+  Enabled: true
+  Include:
+    - '**/migrate/*.rb'

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -17,6 +17,7 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/direct_env_check"
 require "rubocop/cop/ezcater/graphql_fields_naming"
+require "rubocop/cop/ezcater/migration_documentation"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rails_env"
 require "rubocop/cop/ezcater/ruby_timeout"

--- a/lib/rubocop/cop/ezcater/migration_documentation.rb
+++ b/lib/rubocop/cop/ezcater/migration_documentation.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # Enforce use of migration best practices by adding comment of documentation url
+      #
+      # @example
+      #   # bad
+      #   # frozen_string_literal: true
+      #
+      #   class CreateUsers < ActiveRecord::Migration[5.1]
+      #     def change
+      #
+      #   # good
+      #   # frozen_string_literal: true
+      #   # https://ezcater.atlassian.net/wiki/spaces/POL/pages/53248012/Adding+a+migration
+      #
+      #   class CreateUsers < ActiveRecord::Migration[5.1]
+      #     def change
+      #
+      #
+      class MigrationDocumentation < Cop
+        MIGRATION_DOC_URL = "https://ezcater.atlassian.net/wiki/spaces/POL/pages/53248012/Adding+a+migration"
+        MIGRATION_DOC_COMMENT = "# #{MIGRATION_DOC_URL}"
+        MSG = "Missing the comment `#{MIGRATION_DOC_COMMENT}` " \
+              "at the top of your migration file."
+
+        def investigate(processed_source)
+          return if processed_source.tokens.empty?
+
+          ensure_comment(processed_source)
+        end
+
+        def autocorrect(_node)
+          lambda do |corrector|
+            corrector.insert_after(line_range(1), "\n#{MIGRATION_DOC_COMMENT}")
+          end
+        end
+
+        private
+
+        def ensure_comment(processed_source)
+          return if migration_documentation_comment(processed_source)
+
+          missing_offense(processed_source)
+        end
+
+        def migration_documentation_comment(processed_source)
+          processed_source.find_token do |token|
+            token.text.start_with?(MIGRATION_DOC_COMMENT)
+          end
+        end
+
+        def missing_offense(processed_source)
+          range = Parser::Source::Range.new(processed_source.buffer, 1, 2)
+
+          add_offense(processed_source.tokens[0], location: range, message: MSG)
+        end
+
+        def line_range(line)
+          processed_source.buffer.line_range(line)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/migration_documentation_spec.rb
+++ b/spec/rubocop/cop/ezcater/migration_documentation_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::MigrationDocumentation, :config do
+  subject(:cop) { described_class.new }
+
+  let(:error_message) { described_class::MSG }
+
+  it "throws an error when the comment is missing" do
+    source = <<~TEXT
+      # frozen_string_literal: true
+    TEXT
+    inspect_source(source)
+
+    expect(cop.messages).to match_array [error_message]
+  end
+
+  it "does not throw an error when the comment is present" do
+    source = <<~TEXT
+      # frozen_string_literal: true
+      #{described_class::MIGRATION_DOC_COMMENT}
+    TEXT
+    inspect_source(source)
+
+    expect(cop.offenses).to be_empty
+  end
+
+  it "supports autocorrect" do
+    source = <<~TEXT
+      # frozen_string_literal: true
+    TEXT
+    expected_source = <<~TEXT
+      # frozen_string_literal: true
+      #{described_class::MIGRATION_DOC_COMMENT}
+    TEXT
+    inspect_source(source)
+
+    expect(cop.messages).to match_array [error_message]
+    expect(autocorrect_source(source)).to eq(expected_source)
+  end
+end


### PR DESCRIPTION
## [DEL-379](https://ezcater.atlassian.net/browse/DEL-379) What did we change?
- Added a cop to enforce having a comment with a link to the ezCater migration best practices doc.
- Tagged github's suggested peeps. Ignore if you have no opinions!
- Note: I have no idea if I did this correctly...

## Why are we doing this?
We had a crit-sit on the delivery squad a few months back that was caused by a mix up in migrations. We want to make sure that everyone follows the ezCater best practices for writing migrations and this will serve as a reminder with every new migration added.

## How was it tested?
- [x] Specs
- [ ] Locally
