### PR TITLE
Enable Rails/SaveBang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## Unreleased
+- Enable `Rails/SaveBang` with `AllowImplicitReturn: false`, and with autocorrection disabled.
+
 ## v2.0.0
 - Update to `rubocop` v0.81.0, `rubocop-rspec` v1.38.1 and `rubocop-rails` v2.5.2.
 - This is being released as a major update because cops have been renamed so this is unlikely to be

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -47,6 +47,11 @@ Rails/UnknownEnv:
     - staging
     - production
 
+Rails/SaveBang:
+  Enabled: true
+  AllowImplicitReturn: false
+  AutoCorrect: False
+
 Ezcater/RailsTopLevelSqlExecute:
   Description: 'Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations.'
   Enabled: true


### PR DESCRIPTION
## What did we change?

Enabled [Rails/SaveBang](https://rubocop.readthedocs.io/projects/rails/en/stable/cops_rails/#railssavebang).

## Why are we doing this?

This rule catches problematic uses of non-`!` persistence methods like `save`:

```ruby
def foo
  x
  user.save # this might return false
  y
end
```

Without inspecting `user.save` here for `true`/`false`, we're more likely to introduce inconsistent/unexpected states that manifest later on.

`AllowImplicitReturn` seems too permissive if enabled, since it doesn't catch problematic `ary.each { x.save }` instances.

## How was it tested?
- [ ] Specs
- [x] Locally (via the same config in one of our repos)
