### PR TITLE
Set CODEOWNERS to ruby-style-group GH team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @agrobbin @aprescott @tjwp
+* @ezcater/ruby-style-group


### PR DESCRIPTION
## What did we change?

Set CODEOWNERS to ruby-style-group GH team.

## Why are we doing this?

It's time to rotate our style groups. To make this easier in the future, I'm making the @ezcater/ruby-style-group team the owner instead of specific individuals.

## How was it tested?
- [ ] Specs
- [ ] Locally
