### PR TITLE
Add cop for ensuring `EzFF.active?` is called with at least one of the required named arguments to go with our upcoming 2.0.0 release of the gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## v2.3.0
+- Add `FeatureFlagActive` cop. This provides confidence that upgrading to `ezcater_feature_flag-client` v2.0.0, which
+    contains breaking API changes, can be done safely.
+
 ## v2.2.0
 - Require Ruby 2.6 or later.
 - Set `TargetRubyVersion` to 2.6 in `rubocop_gem` configuration.

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -16,6 +16,7 @@ config = RuboCop::ConfigLoader.merge_with_default(config, path)
 RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 
 require "rubocop/cop/ezcater/direct_env_check"
+require "rubocop/cop/ezcater/feature_flag_active"
 require "rubocop/cop/ezcater/graphql_fields_naming"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rails_env"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/lib/rubocop/cop/ezcater/feature_flag_active.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_active.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      # Use `EzcaterFeatureFlag.active?` with a tracking_id or array of identifiers
+      #
+      # @example
+      #
+      #   # good
+      #   EzFF.active?("FlagName", tracking_id: "user:12345")
+      #   EzFF.active?("FlagName", identifiers: ["user:12345", "user:23456"])
+      #
+      #   # bad
+      #   EzFF.active?("FlagName")
+
+      class FeatureFlagActive < Cop
+
+        MSG = "`EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`"
+
+        def_node_matcher :ezff_active_one_arg, <<-PATTERN
+          (send
+            (_ _ {:EzFF :EzcaterFeatureFlag}) :active? (str _))
+        PATTERN
+
+        def_node_matcher :args_matcher, <<-PATTERN
+          (send
+            (_ _ {:EzFF :EzcaterFeatureFlag}) :active?
+              (str _)
+              (_
+                (pair
+                  (sym {:tracking_id :identifiers})
+                  _)
+                ...))
+        PATTERN
+
+        def on_send(node)
+          if ezff_active_one_arg(node) || !args_matcher(node)
+            add_offense(node, location: :expression, message: MSG)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
@@ -1,0 +1,55 @@
+# encoding utf-8
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:flag_name) { "FeatureFlag #{rand(100)}" }
+  let(:tracking_id) { generate_tracking_id }
+
+  let(:msgs) { [described_class::MSG] }
+
+  before { inspect_source(line) }
+
+  %w(EzcaterFeatureFlag EzFF).each do |constant_name|
+    describe "calling #{constant_name}.active?" do
+      context "with a tracking_id" do
+        let(:line) { %[#{constant_name}.active?("#{flag_name}", tracking_id: "#{tracking_id}")] }
+
+        it "does not report an offense" do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context "with an identifiers array" do
+        let(:line) { %[#{constant_name}.active?("#{flag_name}", identifiers: ["#{tracking_id}"])] }
+
+        it "does not report an offense" do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context "with unexpected keyword args" do
+        let(:line) { %[#{constant_name}.active?("#{flag_name}", bad_arg: ["#{tracking_id}"])] }
+
+        it "reports an offense" do
+          expect(cop.messages).to match_array(msgs)
+        end
+      end
+
+      context "with no keyword args" do
+        let(:line) { %[#{constant_name}.active?("#{flag_name}")] }
+
+        it "reports an offense" do
+          expect(cop.messages).to match_array(msgs)
+        end
+      end
+    end
+  end
+
+  def generate_tracking_id
+    [
+      %w(user brand caterer).sample,
+      rand(200)
+    ].join(":")
+  end
+end


### PR DESCRIPTION
## What did we change?

Add new cop `FeatureFlagActive` that ensures the new method signature for `EzcaterFeatureFlag.active?` is respected: https://github.com/ezcater/ezcater_feature_flag-client-ruby/pull/30

This cop will ensure that when `EzFF.active?` is called, it passes in the name of the feature flag to be evaluated, and at least one of either a `tracking_id` or a list of `identifiers` to ensure consistent evaluation.

## Why are we doing this?

We are upgrading the `EzFF` client API to make calling it more descriptive. Moving forward, the `active?` method should only be used when consistent evaluation against an identifier is desired, and the API now enforces passing one of those values. This cops will allow us to find any improper calls using the old API, and direct developers to upgrading either the arguments passed, or the method used.

## How was it tested?
- [x] Specs
- [ ] Locally
