### PR TITLE
Add fix for FeatureFlagActive cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -19,6 +19,10 @@ Ezcater/DirectEnvCheck:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `ENV`.'
   Enabled: false
 
+Ezcater/FeatureFlagActive:
+  Description: 'Enforce the proper arguments are given to EzcaterFeatureFlag.active?'
+  Enabled: true
+
 Ezcater/RspecDotNotSelfDot:
   Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
   Enabled: true

--- a/lib/rubocop/cop/ezcater/feature_flag_active.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_active.rb
@@ -15,7 +15,6 @@ module RuboCop
       #   EzFF.active?("FlagName")
 
       class FeatureFlagActive < Cop
-
         MSG = "`EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`"
 
         def_node_matcher :ezff_active_one_arg, <<-PATTERN
@@ -34,7 +33,14 @@ module RuboCop
                 ...))
         PATTERN
 
+        def_node_matcher :method_call_matcher, <<-PATTERN
+          (send
+            (_ _ {:EzFF :EzcaterFeatureFlag}) :active? ...)
+        PATTERN
+
         def on_send(node)
+          return unless method_call_matcher(node)
+
           if ezff_active_one_arg(node) || !args_matcher(node)
             add_offense(node, location: :expression, message: MSG)
           end

--- a/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
@@ -3,6 +3,7 @@
 
 RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
   subject(:cop) { described_class.new(config) }
+
   let(:flag_name) { "FeatureFlag #{rand(100)}" }
   let(:tracking_id) { generate_tracking_id }
 
@@ -46,10 +47,34 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
     end
   end
 
+  context "other lines that parse to use `send` in the AST don't get caught" do
+    context "require" do
+      let(:line) { 'require "bar"' }
+
+      it "reports nothing" do
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context "config blocks" do
+      let(:line) do
+        <<-RUBY
+        Configuration.config do |config|
+          config.foo = true
+        end
+        RUBY
+      end
+
+      it "reports nothing" do
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
   def generate_tracking_id
     [
       %w(user brand caterer).sample,
-      rand(200)
+      rand(200),
     ].join(":")
   end
 end


### PR DESCRIPTION
## What did we change?

The previous logic was overly broad in what it would flag. Anything that parsed to use `send` in the AST but wasn't a call to `EzFF.active?` would be flagged an invalid. This includes things like `require` and `.config do` blocks.

## Why are we doing this?

The previous logic was catching things that shouldn't have been caught

## How was it tested?
- [x] Specs
- [ ] Locally
