### PR TITLE
Fix `FeatureFlagActive` cop so that it allows feature flag names to be variables in addition to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## v2.4.0
+- Fix `FeatureFlagActive` cop so that it allows feature flag names to be variables in addition to strings.
+- Add check to `FeatureFlagActive` that the first parameter is a string or a variable, and use the appropriate messaging.
+
 ## v2.3.0
 - Add `FeatureFlagActive` cop. This provides confidence that upgrading to `ezcater_feature_flag-client` v2.0.0, which
     contains breaking API changes, can be done safely.

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
## What did we change?

Fix `FeatureFlagActive` cop so that it allows feature flag names to be variables in addition to string

whereas previously only
```
EzFF.active?("FeatureFlag", tracking_id: ...)
```

was considered valid, we now also allow
```
EzFF.active?(defined_feature_flag_name_var, ...)
EzFF.active?(@feature_flag_name_ivar, ...)
```

## Why are we doing this?

In its previous state, this cop expected the feature flag name to be passed in as a string, and was erroneously erroring when the name was passed in as a variable. This was something we forgot to take into account in the first iteration of this, but is a reasonable and expected use case, so we're allowing for it now.

## How was it tested?
- [x] Specs
- [ ] Locally
