### PR TITLE
Bump to latest rubocop 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## v3.0.0
+- Upgrade rubocop:       1.16.0
+- Upgrade rubocop-rails: 2.10.1
+- Upgrade rubocop-rspec: 2.3.0
+- This is a major upgrade because a large number of cops have been introduced, tweaked, or renamed.  Here is an aggregate of the breaking changes introduced
+  - RuboCop assumes that Cop classes do not define new `on_<type>` methods at runtime (e.g. via `extend` in `initialize`).
+  - Enable all pending cops for RuboCop 1.0.
+  - Change logic for cop department name computation. Cops inside deep namespaces (5 or more levels deep) now belong to departments with names that are calculated by joining module names starting from the third one with slashes as separators. For example, cop `Rubocop::Cop::Foo::Bar::Baz` now belongs to `Foo/Bar` department (previously it was `Bar`).
+  - `RegexpNode#parsed_tree` now processes regexps including interpolation (by blanking the interpolation before parsing, rather than skipping).
+  - Cop `Metrics/AbcSize` now counts ||=, &&=, multiple assignments, for, yield, iterating blocks. `&.` now count as conditions too (unless repeated on the same variable). Default bumped from 15 to 17. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+  - Cop `Metrics/PerceivedComplexity` now counts `else` in `case` statements, `&.`, `||=`, `&&=` and blocks known to iterate. Default bumped from 7 to 8. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+  - Extensive refactoring of internal classes `Team`, `Commissioner`, `Corrector`. `Cop::Cop#corrections` not completely compatible. See Upgrade Notes.
+  - `rubocop -a / --autocorrect` no longer run unsafe corrections; `rubocop -A / --autocorrect-all` run both safe and unsafe corrections. Options `--safe-autocorrect` is deprecated.
+  - Order for gems names now disregards underscores and dashes unless `ConsiderPunctuation` setting is set to `true`.
+  - Cop `Metrics/CyclomaticComplexity` now counts `&.`, `||=`, `&&=` and blocks known to iterate. Default bumped from 6 to 7. Consider using `rubocop -a --disable-uncorrectable` to ease transition.
+  - Remove support for unindent/active_support/powerpack from `Layout/HeredocIndentation`, so it only recommends using squiggy heredoc.
+  - Change the max line length of `Layout/LineLength` to 120 by default.
+  - Inspect all files given on command line unless `--only-recognized-file-types` is given.
+  - Enabling a cop overrides disabling its department.
+  - Renamed `Layout/Tab` cop to `Layout/IndentationStyle`.
+  - Drop support for Ruby 2.3.
+  - Drop support for ruby 2.4.
+  - Retire `RSpec/InvalidPredicateMatcher` cop.
+  - Enabled pending cop (`RSpec/StubbedMock`).
+
 ## v2.4.0
 - Fix `FeatureFlagActive` cop so that it allows feature flag names to be variables in addition to strings.
 - Add check to `FeatureFlagActive` that the first parameter is a string or a variable, and use the appropriate messaging.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -2,6 +2,7 @@ require: ezcater_rubocop
 
 AllCops:
   DisplayCopNames: true
+  NewCops: disable
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
@@ -47,6 +48,9 @@ Naming/MethodParameterName:
   - e
   - ex
   - id
+
+Naming/VariableNumber:
+  Enabled: false
 
 Rails:
   Enabled: false
@@ -131,6 +135,9 @@ Style/StderrPuts:
   Exclude:
     - "bin/yarn"
 
+Style/StringConcatenation:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
@@ -145,6 +152,184 @@ Style/TrailingCommaInHashLiteral:
 # Cops are now introduced in a "pending" state and must be explicitly
 # enabled or disabled. New cops are not enabled by default until the
 # next major release.
+
+# New cops introduced between 0.81.0 and 1.16.0
+Layout/BeginEndAlignment:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+
+Layout/IndentationStyle:
+  Enabled: false
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+
+Lint/DuplicateElsifCondition:
+  Enabled: false
+
+Lint/DuplicateRequire:
+  Enabled: false
+
+Lint/DuplicateRescueException:
+  Enabled: false
+
+Lint/EmptyConditionalBody:
+  Enabled: false
+
+Lint/EmptyFile:
+  Enabled: false
+
+Lint/FloatComparison:
+  Enabled: false
+
+Lint/HashCompareByIdentity:
+  Enabled: false
+
+Lint/IdentityComparison:
+  Enabled: false
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+
+Lint/RedundantSafeNavigation:
+  Enabled: false
+
+Lint/SelfAssignment:
+  Enabled: false
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+
+Lint/UnreachableLoop:
+  Enabled: false
+
+Lint/UselessMethodDefinition:
+  Enabled: false
+
+Lint/UselessTimes:
+  Enabled: false
+
+Rails/ArelStar:
+  Enabled: false
+
+Rails/Pick:
+  Enabled: false
+
+Rails/RedundantForeignKey:
+  Enabled: false
+
+RSpec/Capybara/CurrentPathExpectation:
+  Enabled: false
+
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+
+RSpec/Capybara/VisibilityMatcher:
+  Enabled: false
+
+RSpec/EmptyHook:
+  Enabled: false
+
+RSpec/FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+
+RSpec/FactoryBot/CreateList:
+  Enabled: false
+
+RSpec/FactoryBot/FactoryClassName:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/NotToNot:
+  Enabled: false
+
+RSpec/Rails/HttpStatus:
+  Enabled: false
+
+RSpec/RepeatedIncludeExample:
+  Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false
+
+RSpec/VariableDefinition:
+  Enabled: false
+
+RSpec/VariableName:
+  Enabled: false
+
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/BisectedAttrAccessor:
+  Enabled: false
+
+Style/CaseLikeIf:
+  Enabled: false
+
+Style/CombinableLoops:
+  Enabled: false
+
+Style/ExponentialNotation:
+  Enabled: false
+
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/HashAsLastArrayItem:
+  Enabled: false
+
+Style/HashLikeCase:
+  Enabled: false
+
+Style/KeywordParametersOrder:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
+  Enabled: false
+
+Style/RedundantSelfAssignment:
+  Enabled: false
+
+Style/SingleArgumentDig:
+  Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: false
+
+Style/SoleNestedConditional:
+  Enabled: false
 
 #### New cops in v0.81
 

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "< 0.18.0"
 
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
-  spec.add_runtime_dependency "rubocop", "~> 0.81.0"
+  spec.add_runtime_dependency "rubocop", "~> 1.16.0"
   spec.add_runtime_dependency "rubocop-rails", "~> 2.5.2"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.38.1"
 end

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
   spec.add_runtime_dependency "rubocop", "~> 1.16.0"
   spec.add_runtime_dependency "rubocop-rails", "~> 2.10.1"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 1.38.1"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 2.3.0"
 end

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -53,6 +53,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
   spec.add_runtime_dependency "rubocop", "~> 1.16.0"
-  spec.add_runtime_dependency "rubocop-rails", "~> 2.5.2"
+  spec.add_runtime_dependency "rubocop-rails", "~> 2.10.1"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.38.1"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "2.4.0"
+  VERSION = "3.0.0"
 end

--- a/lib/rubocop/cop/ezcater/graphql_fields_naming.rb
+++ b/lib/rubocop/cop/ezcater/graphql_fields_naming.rb
@@ -40,7 +40,7 @@ module RuboCop
 
           return if includes_camelize?(node)
 
-          check_name(node, first_arg.value, node.first_argument.loc.expression)
+          check_name(node, first_arg.value, node.first_argument)
         end
 
         alias on_super on_send

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -24,18 +24,16 @@ module RuboCop
       #   end
 
       class RspecDotNotSelfDot < Cop
+        include RuboCop::RSpec::Language
+
         SELF_DOT_REGEXP = /["']self\./.freeze
         COLON_COLON_REGEXP = /["'](\:\:)/.freeze
 
         SELF_DOT_MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'
         COLON_COLON_MSG = 'Use ".<class method>" instead of "::<class method>" for example group description.'
 
-        def_node_matcher :example_group_match, <<-PATTERN
-          (send _ #{RuboCop::RSpec::Language::ExampleGroups::ALL.node_pattern_union} $_ ...)
-        PATTERN
-
         def on_send(node)
-          example_group_match(node) do |doc|
+          example_group?(node) do |doc|
             if doc.source.match?(SELF_DOT_REGEXP)
               add_offense(doc, location: :expression, message: SELF_DOT_MSG)
             elsif doc.source.match?(COLON_COLON_REGEXP)

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -4,7 +4,7 @@
 RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:ruby_version) { 2.3 }
+  let(:ruby_version) { 2.6 }
   let(:msgs) { [described_class::MSG] }
 
   it "accepts non-nested access" do


### PR DESCRIPTION
Fixes #101 

## What did we change?

- Bumped rubocop to most recent version.
- Bumped rubocop-{rails,rspec} as well
- Disabled a large number of new cops https://github.com/ezcater/ezcater_rubocop/pull/102/commits/872b1634d17e34afc796a326234e8a4b3395586e
- Marked this as a new major version

## Why are we doing this?

1. Application fitness 🏋️ 
2. After 1.0, new cops will be introduced in a default state.  This will make future version bumps much easier.
3. Disabling many of those cops is likely going to be my spicy take of the day.  Bluntly speaking, we should have been doing more minor version bumps along the way.  That would have introduced those cops in pending states and then phased them in to an enabled state.  I suppose we could retroactively step through all the rubocop version bumps, but I'd rather just fast forward past that step.  
4. We've upgraded rubocop major versions.  They had breaking changes.  Therefore we inherited their breaking changes.

## How was it tested?
- [x] Specs
- [ ] Locally
