### PR TITLE
Exclude appraisal generated gemfiles for possible embedded gems in rails apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
 ## v3.0.1
-
 - Fix the RspecDotNotSelfDot cop to work with rubocop-rspec
+- Exclude appraisal generated gemfiles for possible embedded gems in rails apps
 
 ## v3.0.0
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -9,6 +9,7 @@ AllCops:
   TargetRailsVersion: 5.2
   Exclude:
     - tmp/cache/**/*
+    - '**/gemfiles/*.gemfile'
 
 Metrics/BlockLength:
   inherit_mode:


### PR DESCRIPTION
## What did we change?
exclude `**/gemfiles/*.gemfile` from all cops

## Why are we doing this?
if you use `appraisals` in an embedded schemas gem or any other embedded gem, rubocop will run on the generated gemfiles. since these are generated they shouldnt be changed for rubocop's sake

## How was it tested?
- [ ] Specs
- [ ] Locally
