### PR TITLE
Add the CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ezcater_rubocop
+# ezcater_rubocop [![CircleCI](https://circleci.com/gh/ezcater/ezcater_rubocop/tree/main.svg?style=svg)](https://circleci.com/gh/ezcater/ezcater_rubocop/tree/main)
 
 ezCater custom cops and shared RuboCop configuration.
 


### PR DESCRIPTION
## What did we change?
This adds the CircleCI badge to the README

## Why are we doing this?
This is an open source project so we run our specs on CircleCI. Adding the badge makes it clear to users where this is happening.


Closes #103
## How was it tested?
- [ ] Specs
- [ ] Locally
