### PR TITLE
Add support for testing multiple rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,14 @@ orbs:
   ruby: circleci/ruby@1.0
 
 jobs:
-  build:
+  test:
+    parameters:
+      ruby-version:
+        type: string
     parallelism: 1
     working_directory: ~/ezcater
     docker:
-      - image: cimg/ruby:3.1.1
+      - image: cimg/ruby:<< parameters.ruby-version >>
     steps:
       - checkout
 
@@ -45,6 +48,10 @@ jobs:
           path: test_results
 
 workflows:
-  build_and_test:
+  test_all:
     jobs:
-      - build
+      - test:
+          matrix:
+            parameters:
+              # https://github.com/CircleCI-Public/cimg-ruby
+              ruby-version: ["2.6", "2.7", "3.0", "3.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  ruby: circleci/ruby@1.0
+
 jobs:
   build:
     parallelism: 1
@@ -8,18 +12,11 @@ jobs:
     steps:
       - checkout
 
-      # Restore bundle cache
       - restore_cache:
           keys:
             - ruby-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "ezcater_rubocop.gemspec" }}
             - ruby-cache-{{ arch }}-{{ .Branch }}-
             - ruby-cache-
-
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
-            chmod +x ./cc-test-reporter
 
       # Bundle install dependencies
       - run: gem install bundler --no-document -v 2.3.7
@@ -33,20 +30,21 @@ jobs:
             - vendor/bundle
 
       # Run Rubocop
-      - run:
-          name: RuboCop
-          command: bundle exec rubocop
+      - run: bundle exec rubocop
 
       # Run rspec
-      - type: shell
-        command: |
-          ./cc-test-reporter before-build
-          bundle exec rspec --profile 10 \
-                            --format RspecJunitFormatter \
-                            --out test_results/rspec.xml \
-                            --format progress
-          ./cc-test-reporter after-build -t simplecov --exit-code $?
+      - run:
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format RspecJunitFormatter \
+                              --out test_results/rspec.xml \
+                              --format progress
 
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
+
+workflows:
+  build_and_test:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,22 +15,10 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - ruby-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "ezcater_rubocop.gemspec" }}
-            - ruby-cache-{{ arch }}-{{ .Branch }}-
-            - ruby-cache-
-
       # Bundle install dependencies
       - run: gem install bundler --no-document -v 2.3.7
-      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      - run: bundle install --path=vendor/bundle --jobs=4 --retry=3
       - run: bundle clean --force
-
-      # Store bundle cache
-      - save_cache:
-          key: ruby-cache-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "ezcater_rubocop.gemspec" }}
-          paths:
-            - vendor/bundle
 
       # Run Rubocop
       - run: bundle exec rubocop

--- a/.circleci/working_config.yaml
+++ b/.circleci/working_config.yaml
@@ -1,0 +1,78 @@
+version: 2.1 # Use 2.1 to enable using orbs and other features.
+
+# Declare the orbs that we'll use in our config.
+# read more about orbs: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  ruby: circleci/ruby@1.0
+  node: circleci/node@2
+
+jobs:
+  build: # our first job, named "build"
+    docker:
+      - image: cimg/ruby:2.7-node # use a tailored CircleCI docker image.
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+    steps:
+      - checkout # pull down our git code.
+      - ruby/install-deps # use the ruby orb to install dependencies
+      # use the node orb to install our packages
+      # specifying that we use `yarn` and to cache dependencies with `yarn.lock`
+      # learn more: https://circleci.com/docs/2.0/caching/
+      - node/install-packages:
+          pkg-manager: yarn
+          cache-key: "yarn.lock"
+
+  test:  # our next job, called "test"
+    # we run "parallel job containers" to enable speeding up our tests;
+    # this splits our tests across multiple containers.
+    parallelism: 3
+    # here we set TWO docker images.
+    docker:
+      - image: cimg/ruby:2.7-node # this is our primary docker image, where step commands run.
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+      - image: cimg/postgres:14.0
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+        environment: # add POSTGRES environment variables.
+          POSTGRES_USER: circleci-demo-ruby
+          POSTGRES_DB: rails_blog_test
+          POSTGRES_PASSWORD: ""
+    # environment variables specific to Ruby/Rails, applied to the primary container.
+    environment:
+      BUNDLE_JOBS: "3"
+      BUNDLE_RETRY: "3"
+      PGHOST: 127.0.0.1
+      PGUSER: circleci-demo-ruby
+      PGPASSWORD: ""
+      RAILS_ENV: test
+    # A series of steps to run, some are similar to those in "build".
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          pkg-manager: yarn
+          cache-key: "yarn.lock"
+      # Here we make sure that the secondary container boots
+      # up before we run operations on the database.
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: Database setup
+          command: bundle exec rails db:schema:load --trace
+      # Run rspec in parallel
+      - ruby/rspec-test
+
+# We use workflows to orchestrate the jobs that we declared above.
+workflows:
+  version: 2
+  build_and_test:     # The name of our workflow is "build_and_test"
+    jobs:             # The list of jobs we run as part of this workflow.
+      - build         # Run build first.
+      - test:         # Then run test,
+          requires:   # Test requires that build passes for it to run.
+            - build   # Finally, run the build job.


### PR DESCRIPTION
## What did we change?
* Update to the 2.1 version of CircleCI config
* Add support for testing multiple rubies. We require 2.6 or greater but we're only testing on 3.1 currently. This helps cover other ruby versions
* Remove the bundle caching - we don't have a gemfile lock so it's not as reliable to rebuild the same build each time. It's worth doing a fresh pull (the entire CI run only takes 30 seconds)

## Why are we doing this?

## How was it tested?
- [X] Specs
- [X] Locally
