### PR TITLE
Add documentation for adding new cops and release existing cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 5.0.0
+- Enable all added cops since 0.8. There are a lot of new cops now, be sure to use `--regenerate-todo` if you're on a large project that can't be updated easily.
+
 ## 4.0.0
 
 - Add the [rubcop-graphql](https://github.com/DmitryTsepelev/rubocop-graphql) helpers and enable

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ running rubocop.
 
 This gem is using [Semantic Versioning](https://semver.org/). All version bumps should increment using `MAJOR.MINOR.PATCH` based on changes.
 
+When adding a new cop, please enable the cop and release a new major version. This allows us to
+constantly roll out improvements without clients having their suite break unknowingly. When a
+breaking change is released, users can opt to use `--regenerate-todo` to update their TODO file. Do
+not add cops with `enabled: false` unless you want that cop to always be disabled.
+
 ## Custom Cops
 
 1. [RailsConfiguration](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/rails_configuration.rb) - Enforce use of `Rails.configuration` instead of `Rails.application.config`.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -148,192 +148,189 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
+
 Layout/BeginEndAlignment:
-  Enabled: false
+  Enabled: true
 
 Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: false
+  Enabled: true
 
 Layout/IndentationStyle:
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAroundMethodCallOperator:
-  Enabled: false
+  Enabled: true
 
 Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: false
+  Enabled: true
 
 Lint/ConstantDefinitionInBlock:
-  Enabled: false
+  Enabled: true
 
 Lint/DeprecatedOpenSSLConstant:
-  Enabled: false
+  Enabled: true
 
 Lint/DuplicateElsifCondition:
-  Enabled: false
+  Enabled: true
 
 Lint/DuplicateRequire:
-  Enabled: false
+  Enabled: true
 
 Lint/DuplicateRescueException:
-  Enabled: false
+  Enabled: true
 
 Lint/EmptyConditionalBody:
-  Enabled: false
+  Enabled: true
 
 Lint/EmptyFile:
-  Enabled: false
+  Enabled: true
 
 Lint/FloatComparison:
-  Enabled: false
+  Enabled: true
 
 Lint/HashCompareByIdentity:
-  Enabled: false
+  Enabled: true
 
 Lint/IdentityComparison:
-  Enabled: false
+  Enabled: true
 
 Lint/MissingSuper:
-  Enabled: false
+  Enabled: true
 
 Lint/MixedRegexpCaptureTypes:
-  Enabled: false
+  Enabled: true
 
 Lint/OutOfRangeRegexpRef:
-  Enabled: false
+  Enabled: true
 
 Lint/RedundantSafeNavigation:
-  Enabled: false
+  Enabled: true
 
 Lint/SelfAssignment:
-  Enabled: false
+  Enabled: true
 
 Lint/TopLevelReturnWithArgument:
-  Enabled: false
+  Enabled: true
 
 Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: false
+  Enabled: true
 
 Lint/UnreachableLoop:
-  Enabled: false
+  Enabled: true
 
 Lint/UselessMethodDefinition:
-  Enabled: false
+  Enabled: true
 
 Lint/UselessTimes:
-  Enabled: false
+  Enabled: true
 
 Rails/ArelStar:
-  Enabled: false
+  Enabled: true
 
 Rails/Pick:
-  Enabled: false
+  Enabled: true
 
 Rails/RedundantForeignKey:
-  Enabled: false
+  Enabled: true
 
 RSpec/Capybara/CurrentPathExpectation:
-  Enabled: false
+  Enabled: true
 
 RSpec/Capybara/FeatureMethods:
-  Enabled: false
+  Enabled: true
 
 RSpec/Capybara/VisibilityMatcher:
-  Enabled: false
+  Enabled: true
 
 RSpec/EmptyHook:
-  Enabled: false
+  Enabled: true
 
 RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
+  Enabled: true
 
 RSpec/FactoryBot/CreateList:
-  Enabled: false
+  Enabled: true
 
 RSpec/FactoryBot/FactoryClassName:
-  Enabled: false
+  Enabled: true
 
 RSpec/MultipleMemoizedHelpers:
-  Enabled: false
+  Enabled: true
 
 RSpec/NotToNot:
-  Enabled: false
+  Enabled: true
 
 RSpec/Rails/HttpStatus:
-  Enabled: false
+  Enabled: true
 
 RSpec/RepeatedIncludeExample:
-  Enabled: false
+  Enabled: true
 
 RSpec/StubbedMock:
-  Enabled: false
+  Enabled: true
 
 RSpec/VariableDefinition:
-  Enabled: false
+  Enabled: true
 
 RSpec/VariableName:
-  Enabled: false
+  Enabled: true
 
 Style/AccessorGrouping:
-  Enabled: false
+  Enabled: true
 
 Style/BisectedAttrAccessor:
-  Enabled: false
+  Enabled: true
 
 Style/CaseLikeIf:
-  Enabled: false
+  Enabled: true
 
 Style/CombinableLoops:
-  Enabled: false
+  Enabled: true
 
 Style/ExponentialNotation:
-  Enabled: false
+  Enabled: true
 
 Style/GlobalStdStream:
-  Enabled: false
+  Enabled: true
 
 Style/HashAsLastArrayItem:
-  Enabled: false
+  Enabled: true
 
 Style/HashLikeCase:
-  Enabled: false
+  Enabled: true
 
 Style/KeywordParametersOrder:
-  Enabled: false
+  Enabled: true
 
 Style/OptionalBooleanParameter:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantAssignment:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantRegexpCharacterClass:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantRegexpEscape:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantSelfAssignment:
-  Enabled: false
+  Enabled: true
 
 Style/SingleArgumentDig:
-  Enabled: false
+  Enabled: true
 
 Style/SlicingWithRange:
-  Enabled: false
+  Enabled: true
 
 Style/SoleNestedConditional:
-  Enabled: false
-
-#### New cops in v0.81
+  Enabled: true
 
 Lint/RaiseException:
   Enabled: true
 
 Lint/StructNewOverride:
   Enabled: true
-
-#### New cops in v0.80
 
 Style/HashEachMethods:
   Enabled: true

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -148,13 +148,6 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
-### New Cops
-
-# Cops are now introduced in a "pending" state and must be explicitly
-# enabled or disabled. New cops are not enabled by default until the
-# next major release.
-
-# New cops introduced between 0.81.0 and 1.16.0
 Layout/BeginEndAlignment:
   Enabled: false
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "4.0.0"
+  VERSION = "5.0.0"
 end

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -36,7 +36,7 @@ module RuboCop
         end.flatten + %w(its focus skip)).freeze
 
         SELF_DOT_REGEXP = /\Aself\./.freeze # rubocop:disable Style/RedundantFreeze
-        COLON_COLON_REGEXP = /\A(\:\:)/.freeze # rubocop:disable Style/RedundantFreeze
+        COLON_COLON_REGEXP = /\A(::)/.freeze # rubocop:disable Style/RedundantFreeze
 
         SELF_DOT_MSG = 'Use ".<class method>" instead of "self.<class method>" for example group description.'
         COLON_COLON_MSG = 'Use ".<class method>" instead of "::<class method>" for example group description.'


### PR DESCRIPTION
## What did we change?
This enables a LOT of cops and cuts a new release with them enabled.

## Why are we doing this?

At some point we had a suggestion that new cops were to be added as `enabled: false` and then enabled on future major releases. This didn't work as planned and we had a lot of cops that were added and never enabled. To prevent this situation from happening again, I updated the documented guidance on new cops.

## How was it tested?
- [ ] Specs
- [ ] Locally
