### PR TITLE
[INT-1392] Change path for disabling cops to be more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 5.1.0
+- Change paths to exclude for various cops to be agnostic of directory structure prior to the matching string. This is to allow apps to have greater flexibility in where files live, but still have them excluded from certain cops. The need for this arose when implementing Stimpack, which moves specs and other files under app/packs/[pack_name].
+
 ## 5.0.0
 - Enable all added cops since 0.8. There are a lot of new cops now, be sure to use `--regenerate-todo` if you're on a large project that can't be updated easily.
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - "*.gemspec"
-    - "spec/**/*.rb"
+    - "/**/spec/**/*.rb"
 
 Metrics/CyclomaticComplexity:
   Enabled: false
@@ -61,12 +61,12 @@ RSpec/ContextWording:
 
 RSpec/DescribeClass:
   Exclude:
-    - "spec/requests/**/*.rb"
-    - "spec/features/**/*.rb"
-    - "spec/routing/**/*.rb"
-    - "spec/views/**/*.rb"
-    - "spec/system/**/*.rb"
-    - "spec/integrations/**/*.rb"
+    - "/**/spec/features/**/*.rb"
+    - "/**/spec/requests/**/*.rb"
+    - "/**/spec/routing/**/*.rb"
+    - "/**/spec/views/**/*.rb"
+    - "/**/spec/system/**/*.rb"
+    - "/**/spec/integrations/**/*.rb"
 
 RSpec/ExampleLength:
   Max: 25

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -17,8 +17,8 @@ Metrics/BlockLength:
       - Exclude
   Exclude:
   - "app/graphql/**/*.rb"
-  - "config/environments/*.rb"
-  - "lib/tasks/**/*.rake"
+  - "/**/config/environments/*.rb"
+  - "/**/lib/tasks/**/*.rake"
 
 Rails:
   Enabled: true
@@ -63,19 +63,19 @@ Ezcater/RailsEnv:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `Rails.env`.'
   Enabled: true
   Exclude:
-    - "config/**/*"
-    - "spec/rails_helper.rb"
+    - "/**/config/**/*"
+    - "/**/spec/rails_helper.rb"
     - "db/**/*"
-    - "lib/tasks/**/*"
-    - "spec/lib/tasks/**/*"
+    - "/**/lib/tasks/**/*"
+    - "/**/spec/lib/tasks/**/*"
 
 Ezcater/DirectEnvCheck:
   Description: 'Enforce the use of `Rails.configuration.x.<foo>` instead of checking `ENV`.'
   Enabled: true
   Exclude:
     - "bin/**/*"
-    - "config/**/*"
-    - "spec/rails_helper.rb"
+    - "/**/config/**/*"
+    - "/**/spec/rails_helper.rb"
     - "db/**/*"
-    - "lib/tasks/**/*"
-    - "spec/lib/tasks/**/*"
+    - "/**/lib/tasks/**/*"
+    - "/**/spec/lib/tasks/**/*"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "5.0.0"
+  VERSION = "5.1.0"
 end


### PR DESCRIPTION
## What did we change?
Changed the paths that we exclude various cops on to be more generic of the directory structure upstream of where we want to disable the cop.
## Why are we doing this?
When implementing Stimpack, files often move to under `packs/[pack name]`. This change allows us to implement a change to the directory structure such as this, and still disable cops for the appropriate files.
## How was it tested?
- [ ] Specs
- [ ] Locally
