### PR TITLE
Update rubocop to 0.90.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## v2.5.0
+- Update rubocop to 0.90.0
+
 ## v2.4.0
 - Fix `FeatureFlagActive` cop so that it allows feature flag names to be variables in addition to strings.
 - Add check to `FeatureFlagActive` that the first parameter is a string or a variable, and use the appropriate messaging.

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "< 0.18.0"
 
   spec.add_runtime_dependency "parser", "!= 2.5.1.1"
-  spec.add_runtime_dependency "rubocop", "~> 0.81.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.90.0"
   spec.add_runtime_dependency "rubocop-rails", "~> 2.5.2"
   spec.add_runtime_dependency "rubocop-rspec", "~> 1.38.1"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
 end


### PR DESCRIPTION
## What did we change?

I created a `2-x-stable` branch off of `2.4.0` tag to allow us to bump up ez-rails `rubocop` to get some fixes in for another gem that we would like to use to validate packwerk.   Basically `RuboCop::Cop::Base` was added in [0.8.7](https://github.com/rubyatscale/rubocop-packs/issues/47) but I had to bring it up to 0.9.0 to get a fix for [this issue](https://github.com/rubocop/rubocop/issues/8713).  Once I merge this back to `2-x-stable` I will cut a release from there.

## How was it tested?
- [ ] Specs
- [x] Locally
