### PR TITLE
Fix the wrong namespace for some Capybara cops.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 5.2.1
+- Fix the has the wrong namespace for `RSpec/Capybara/CurrentPathExpectation` and `RSpec/Capybara/VisibilityMatcher` cops, since [they've been extracted](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2180-2023-01-16) into a separate repo [rubocop-capybara](https://github.com/rubocop/rubocop-capybara).
+
 ## 5.2.0
 
 - Add an explicit rule for `Style/HashSyntax`, setting `EnforcedShorthandSyntax: either`.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -233,13 +233,13 @@ Rails/Pick:
 Rails/RedundantForeignKey:
   Enabled: true
 
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
+  Enabled: true
+
+Capybara/VisibilityMatcher:
   Enabled: true
 
 RSpec/Capybara/FeatureMethods:
-  Enabled: true
-
-RSpec/Capybara/VisibilityMatcher:
   Enabled: true
 
 RSpec/EmptyHook:

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "5.2.0"
+  VERSION = "5.2.1"
 end


### PR DESCRIPTION
## What did we change?

Fix the wrong namespace for `RSpec/Capybara/CurrentPathExpectation` and `RSpec/Capybara/VisibilityMatcher` cops. They are now under the `Capybara` namespace, instead of `RSpec/Capybara`. 

## Why are we doing this?

[They've been extracted](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2180-2023-01-16) into a separate repo [rubocop-capybara](https://github.com/rubocop/rubocop-capybara).

This will take care of the following warnings:

```ruby
conf/rubocop.yml: RSpec/Capybara/CurrentPathExpectation has the wrong namespace - should be Capybara
conf/rubocop.yml: RSpec/Capybara/VisibilityMatcher has the wrong namespace - should be Capybara
```

## How was it tested?
- [ ] Specs
- [ ] Locally
