### PR TITLE
[DEM-266] Correct titlecase regex bug in `FeatureFlagNameValid` cop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,4 @@ workflows:
           matrix:
             parameters:
               # https://github.com/CircleCI-Public/cimg-ruby
-              ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+              ruby-version: ["2.7", "3.0", "3.1"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.0.1
+- Fix a bug in the `FeatureFlagNameValid` cop where the titlecase regex matcher was incorrectly finding offenses.
+
 ## 6.0.0
 - Add `FeatureFlagNameValid` cop to validate correct feature flag name format, [adopted from the cop](https://github.com/ezcater/ez-rails/blob/2d9272eb3d2c71dc5ebc2aa01a849cf9cfae3df2/cops/rubocop/cops/feature_flags_flag_name.rb_) in `ez-rails`.
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.0.0"
+  VERSION = "6.0.1"
 end

--- a/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
@@ -26,7 +26,7 @@ module RuboCop
         ISOLATED_COLON = /(?<!:):(?!:)/.freeze
         TRIPLE_COLON = /:::/.freeze
         INVALID_CHARACTERS = /[^a-zA-Z0-9:]/.freeze
-        TITLECASE_SEGMENT = /"^([A-Z][a-z0-9]*)+$"/.freeze
+        TITLECASE_SEGMENT = /^([A-Z][a-z0-9]*)+$/.freeze
 
         WHITESPACE_MSG = "Feature flag names must not contain whitespace."
         DOUBLE_COLON_MSG = "Feature flag names must use double colons (::) as namespace separators."
@@ -39,7 +39,7 @@ module RuboCop
 
         def_node_matcher :feature_flag_method_call, <<~PATTERN
           (send
-            (_ _ {:EzFF :EzcaterFeatureFlag}) {:active? | :at_100? | :random_sample_active?} (str $_ ...))
+            (_ _ {:EzFF :EzcaterFeatureFlag}) {:active? | :at_100? | :random_sample_active?} <(str $_) ...>)
         PATTERN
 
         def on_casgn(node)

--- a/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
@@ -22,11 +22,11 @@ module RuboCop
       #   EzFF.active?("foo::bar", identifiers: ["user:1"])
       #   MY_FLAG="Foo:bar"
       class FeatureFlagNameValid < Cop
-        WHITESPACE = /\s/.freeze
-        ISOLATED_COLON = /(?<!:):(?!:)/.freeze
-        TRIPLE_COLON = /:::/.freeze
-        INVALID_CHARACTERS = /[^a-zA-Z0-9:]/.freeze
-        TITLECASE_SEGMENT = /^([A-Z][a-z0-9]*)+$/.freeze
+        WHITESPACE = /\s/
+        ISOLATED_COLON = /(?<!:):(?!:)/
+        TRIPLE_COLON = /:::/
+        INVALID_CHARACTERS = /[^a-zA-Z0-9:]/
+        TITLECASE_SEGMENT = /^([A-Z][a-z0-9]*)+$/
 
         WHITESPACE_MSG = "Feature flag names must not contain whitespace."
         DOUBLE_COLON_MSG = "Feature flag names must use double colons (::) as namespace separators."
@@ -53,7 +53,7 @@ module RuboCop
 
         def on_send(node)
           return unless feature_flag_method_call(node)
-            
+
           feature_flag_method_call(node) do |flag_name|
             errors = find_name_violations(flag_name)
             add_offense(node, location: :expression, message: errors.join(", ")) if errors.any?
@@ -88,5 +88,5 @@ module RuboCop
         end
       end
     end
-  end 
+  end
 end

--- a/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
   subject(:cop) { described_class.new(config) }
 
   before { inspect_source(line) }
+
   describe "assignment to a constant" do
     %w(_FF _FLAG _FLAG_NAME _FEATURE_FLAG).each do |suffix|
       describe "assignment to a constant ending in #{suffix}" do
         %w(Flag1 Foo Foo::Bar Foo::Bar::Baz).each do |valid_flag_name|
           context "with a valid feature flag name: #{valid_flag_name}" do
-            let(:line) { %[SOMETHING#{suffix} = #{valid_flag_name}] }
-      
+            let(:line) { %(SOMETHING#{suffix} = #{valid_flag_name}) }
+
             it "does not report an offense" do
               expect(cop.offenses).to be_empty
             end
@@ -18,36 +19,36 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
         end
 
         context "with an invalid feature flag name: flag1" do
-          let(:line) { %[SOMETHING#{suffix} = "flag1"] }
-    
+          let(:line) { %(SOMETHING#{suffix} = "flag1") }
+
           it "reports an offense for titlecase" do
             expect(cop.messages).to match_array(["Feature flag names must use titlecase for each segment."])
           end
         end
 
         context "with an invalid feature flag name: Foo:bar" do
-          let(:line) { %[SOMETHING#{suffix} = "Foo:bar"] }
-    
+          let(:line) { %(SOMETHING#{suffix} = "Foo:bar") }
+
           it "reports an offense for single colon use and titlecase" do
             expect(cop.messages).to match_array(
               [
                 "Feature flag names must use double colons (::) as namespace separators., " \
-                "Feature flag names must use titlecase for each segment."
+                "Feature flag names must use titlecase for each segment.",
               ]
             )
           end
         end
 
         context "with an invalid feature flag name: Foo:::Bar " do
-          let(:line) { %[SOMETHING#{suffix} = "Foo :::B%ar"] }
-    
+          let(:line) { %(SOMETHING#{suffix} = "Foo :::B%ar") }
+
           it "reports an offense for triple colon use and whitespace" do
             expect(cop.messages).to match_array(
               [
                 "Feature flag names must not contain whitespace., " \
                 "Feature flag names must use double colons (::) as namespace separators., " \
                 "Feature flag names must only contain alphanumeric characters and colons., " \
-                "Feature flag names must use titlecase for each segment."
+                "Feature flag names must use titlecase for each segment.",
               ]
             )
           end
@@ -74,14 +75,14 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
             expect(cop.messages).to match_array(
               [
                 "Feature flag names must use double colons (::) as namespace separators., " \
-                "Feature flag names must use titlecase for each segment."
+                "Feature flag names must use titlecase for each segment.",
               ]
             )
           end
 
           context "without a tracking id" do
             let(:line) { %[#{klass_name}.#{method_name}("Foobar")] }
-  
+
             it "does not report an offense" do
               expect(cop.offenses).to be_empty
             end

--- a/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
     %w(active? at_100? random_sample_active?).each do |method_name|
       describe "method call to #{klass_name}.#{method_name}" do
         context "with a valid feature flag name" do
-          let(:line) { %[#{klass_name}.#{method_name}("Foo::Bar", tracking_id: 1234)] }
+          let(:line) { %[#{klass_name}.#{method_name}("Foo::Bar")] }
 
           it "does not report an offense" do
             expect(cop.offenses).to be_empty
@@ -77,6 +77,15 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
                 "Feature flag names must use titlecase for each segment."
               ]
             )
+          end
+
+          context "without a tracking id" do
+            let(:line) { %[#{klass_name}.#{method_name}("Foobar")] }
+  
+            it "does not report an offense" do
+              puts line
+              expect(cop.offenses).to be_empty
+            end
           end
         end
       end

--- a/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
     %w(active? at_100? random_sample_active?).each do |method_name|
       describe "method call to #{klass_name}.#{method_name}" do
         context "with a valid feature flag name" do
-          let(:line) { %[#{klass_name}.#{method_name}("Foo::Bar")] }
+          let(:line) { %[#{klass_name}.#{method_name}("Foo::Bar", tracking_id: 1234)] }
 
           it "does not report an offense" do
             expect(cop.offenses).to be_empty
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
           end
 
           context "without a tracking id" do
-            let(:line) { %[#{klass_name}.#{method_name}("foobar")] }
+            let(:line) { %[#{klass_name}.#{method_name}("Foobar")] }
   
             it "does not report an offense" do
               expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
@@ -80,10 +80,9 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
           end
 
           context "without a tracking id" do
-            let(:line) { %[#{klass_name}.#{method_name}("Foobar")] }
+            let(:line) { %[#{klass_name}.#{method_name}("foobar")] }
   
             it "does not report an offense" do
-              puts line
               expect(cop.offenses).to be_empty
             end
           end

--- a/spec/rubocop/cop/ezcater/rails_configuration_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_configuration_spec.rb
@@ -4,7 +4,7 @@
 RSpec.describe RuboCop::Cop::Ezcater::RailsConfiguration do
   subject(:cop) { described_class.new }
 
-  let(:msgs) { [described_class::MSG] }
+  let(:msgs) { ["Ezcater/RailsConfiguration: #{described_class::MSG}"] }
 
   it "accepts Rails.configuration" do
     source = "Rails.configuration.foobar"

--- a/spec/rubocop/cop/ezcater/rails_top_level_sql_execute_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_top_level_sql_execute_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Ezcater::RailsTopLevelSqlExecute do
   subject(:cop) { described_class.new }
 
-  let(:msgs) { [described_class::MSG] }
+  let(:msgs) { ["Ezcater/RailsTopLevelSqlExecute: #{described_class::MSG}"] }
 
   it "accepts `execute`" do
     source = "execute('SELECT * FROM foo')"

--- a/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
+++ b/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe RuboCop::Cop::Ezcater::RequireGqlErrorHelpers, :config do
   subject(:cop) { described_class.new }
 
-  let(:error_message) { described_class::MSG }
+  let(:error_message) { "Ezcater/RequireGqlErrorHelpers: #{described_class::MSG}" }
   let(:expected_source) { "GraphQL::ExecutionError" }
 
   context "when attempting to directly use GraphQL::ExecutionError" do

--- a/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.shared_examples_for "a browser class that should be mocked" do |klass|
-  let(:error_message) { format(described_class::MSG, node_source: klass) }
+  let(:error_message) { format("Ezcater/RspecRequireBrowserMock: #{described_class::MSG}", node_source: klass) }
 
   context "when the class is '#{klass}'" do
     it "registers an offense when attempting to directly mock #{klass}" do

--- a/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_feature_flag_mock_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireFeatureFlagMock, :config do
 
   it "registers an offense when attempting to directly mock FeatureFlag" do
     inspect_source("allow(FeatureFlag).to receive(:is_active?).and_return(true)")
-    expect(cop.messages).to match_array([described_class::MSG])
+    expect(cop.messages).to match_array(["Ezcater/RspecRequireFeatureFlagMock: #{described_class::MSG}"])
     expect(cop.highlights).to match_array(["allow(FeatureFlag).to receive(:is_active?).and_return(true)"])
   end
 
   it "registers an offense when attempting to directly mock FeatureFlag with bad formatting" do
     inspect_source("allow   (    FeatureFlag  ).to receive(:is_active?).and_return(true)")
-    expect(cop.messages).to match_array([described_class::MSG])
+    expect(cop.messages).to match_array(["Ezcater/RspecRequireFeatureFlagMock: #{described_class::MSG}"])
     expect(cop.highlights).to match_array(["allow   (    FeatureFlag  ).to receive(:is_active?).and_return(true)"])
   end
 end

--- a/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
@@ -12,13 +12,17 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecRequireHttpStatusMatcher do
 
   it "registers an offence when attempting to assert directly on the status" do
     inspect_source("expect(response.status).to eq 400")
-    expect(cop.messages).to match_array(["Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`"])
+    expect(cop.messages).to match_array(
+      ["Ezcater/RspecRequireHttpStatusMatcher: Use the `have_http_status` matcher, like "\
+      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`"]
+    )
   end
 
   it "registers an offence when attempting to assert directly on the code" do
     inspect_source("expect(response.code).to eq \"400\"")
-    expect(cop.messages).to match_array(["Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq \"400\"`"])
+    expect(cop.messages).to match_array(
+      ["Ezcater/RspecRequireHttpStatusMatcher: Use the `have_http_status` matcher, like "\
+      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq \"400\"`"]
+    )
   end
 end

--- a/spec/rubocop/cop/ezcater/ruby_timeout_spec.rb
+++ b/spec/rubocop/cop/ezcater/ruby_timeout_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::Ezcater::RubyTimeout do
   subject(:cop) { described_class.new }
 
-  let(:msgs) { [described_class::MSG] }
+  let(:msgs) { ["Ezcater/RubyTimeout: #{described_class::MSG}"] }
 
   it "detects `Timeout.timeout(n)`" do
     source = "Timeout.timeout(n) { foo }"


### PR DESCRIPTION
## What did we change?
Fix a bug in `FeatureFlagNameValid` cop.

## Why are we doing this?
There was a typo in the `TITLECASE_SEGMENT` regex, causing it to incorrectly identify valid flag names.

## How was it tested?
- [x] Specs
- [ ] Locally
