### PR TITLE
Fix FactoryBot namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.0.2
+- Upgrade rubocop-rspec to v2.22.0 to use the new FactoryBot namespaces.
+- Fix the following wrong namespaces related to `FactoryBot`: `RSpec/FactoryBot/AttributeDefinedStatically`, `RSpec/FactoryBot/CreateList` and `RSpec/FactoryBot/FactoryClassName`.
+
 ## 6.0.1
 - Fix a bug in the `FeatureFlagNameValid` cop where the titlecase regex matcher was incorrectly finding offenses.
 
@@ -13,7 +17,7 @@ Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of R
 - Add `FeatureFlagNameValid` cop to validate correct feature flag name format, [adopted from the cop](https://github.com/ezcater/ez-rails/blob/2d9272eb3d2c71dc5ebc2aa01a849cf9cfae3df2/cops/rubocop/cops/feature_flags_flag_name.rb_) in `ez-rails`.
 
 ## 5.2.1
-- Fix the has the wrong namespace for `RSpec/Capybara/CurrentPathExpectation` and `RSpec/Capybara/VisibilityMatcher` cops, since [they've been extracted](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2180-2023-01-16) into a separate repo [rubocop-capybara](https://github.com/rubocop/rubocop-capybara).
+- Fix the wrong namespace for `RSpec/Capybara/CurrentPathExpectation` and `RSpec/Capybara/VisibilityMatcher` cops, since [they've been extracted](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2180-2023-01-16) into a separate repo [rubocop-capybara](https://github.com/rubocop/rubocop-capybara).
 
 ## 5.2.0
 

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -245,13 +245,13 @@ RSpec/Capybara/FeatureMethods:
 RSpec/EmptyHook:
   Enabled: true
 
-RSpec/FactoryBot/AttributeDefinedStatically:
+FactoryBot/AttributeDefinedStatically:
   Enabled: true
 
-RSpec/FactoryBot/CreateList:
+FactoryBot/CreateList:
   Enabled: true
 
-RSpec/FactoryBot/FactoryClassName:
+FactoryBot/FactoryClassName:
   Enabled: true
 
 RSpec/MultipleMemoizedHelpers:

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -55,5 +55,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop", ">= 1.16.0", "< 2.0"
   spec.add_runtime_dependency "rubocop-graphql", ">= 0.14.0", "< 1.0"
   spec.add_runtime_dependency "rubocop-rails", ">= 2.10.1", "< 3.0"
-  spec.add_runtime_dependency "rubocop-rspec", ">= 2.3.0", "< 3.0"
+  spec.add_runtime_dependency "rubocop-rspec", ">= 2.22.0", "< 3.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.0.1"
+  VERSION = "6.0.2"
 end


### PR DESCRIPTION
Address the following warnings:

- `RSpec/FactoryBot/AttributeDefinedStatically has the wrong namespace - should be FactoryBot`
- `RSpec/FactoryBot/CreateList has the wrong namespace - should be FactoryBot`
- `RSpec/FactoryBot/FactoryClassName has the wrong namespace - should be FactoryBot`

## How was it tested?
- [ ] Specs
- [x] Locally
