### PR TITLE
feat: Add Ezcater/GraphQL/NotAuthorizedScalarField cop, et al.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,5 +9,9 @@ inherit_from:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/FilePath:
+  Exclude:
+    - spec/rubocop/cop/ezcater/graphql/not_authorized_scalar_field_spec.rb
+
 Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.1.0
+
+- Add `Ezcater/GraphQL/NotAuthorizedScalarField` Cop which enforces the use
+  of authorization for scalar GraphQL fields. Not enforced by default.
+
 ## 6.0.3
 - Fix `FeatureFlagActive` cop so that it allows feature flag names to be constants and dot method calls in addition to strings.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ not add cops with `enabled: false` unless you want that cop to always be disable
 
 * [FeatureFlagActive](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/feature_flag_active.rb) - Enforce the proper arguments are given to `EzcaterFeatureFlag.active?`
 * [FeatureFlagNameValid](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb) - Enforce correct flag name format is being used.
+* [GraphQL/NotAuthorizedScalarField] - Enforces the use of
+  authorization (pundit or, optionally, the guard pattern) for scalar
+  fields. See examples within class comment for additional configuration.
 * [RailsConfiguration](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/rails_configuration.rb) - Enforce use of `Rails.configuration` instead of `Rails.application.config`.
 * [RequireGqlErrorHelpers](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb) - Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.
 * [RspecDotNotSelfDot](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb) - Enforce ".<class method>" instead of "self.<class method>" and "::<class method>" for example group description.
@@ -89,6 +92,8 @@ not add cops with `enabled: false` unless you want that cop to always be disable
 * [RspecRequireFeatureFlagMock](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb) - Enforce use of `mock_feature_flag` helper instead of mocking `FeatureFlag.is_active?` directly.
 * [RspecRequireHttpStatusMatcher](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb) - Use the HTTP status code matcher, like `expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq 400`
 * [StyleDig](https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/style_dig.rb) - Recommend `dig` for deeply nested access.
+
+[GraphQL/NotAuthorizedScalarField]: https://github.com/ezcater/ezcater_rubocop/blob/main/lib/rubocop/cop/ezcater/graphql/not_authorized_scalar_field.rb)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,47 @@ To release a new version, update the version number in `version.rb`, merge your 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/ezcater/ezcater_rubocop.
 
+### Adding New Cops
+
+New cops can be generated via the `new_cop` rake task which generates
+the cop, the spec, updates imports, and adds configuration. Example:
+
+``` shell
+rake 'new_cop[Ezcater/foo_bar]'
+```
+
+Follow the instructions after the task executes and update code as
+necessary for consistency.
+
+
+In addition, you need to:
+
+1. Add the cop to the "Custom Cops" section of this README
+2. Bump the version.
+3. Add a CHANGELOG entry.
+
+
+### Version Bumps & Changelog Entries
+
+The version for this gem follows [Semantic Versioning]:
+
+1. Bump the MAJOR version for breaking changes. Example: new cop,
+   enabled by default and which cannot be safely autofixed.
+
+2. Bump the MINOR version for new functionality which will not disrupt
+   projects which depend on this gem. Example: new cop, not enabled by
+   default or which can safely be autofixed.
+
+3. Bump the PATCH version for backwards compatible bugfixes.
+
+[Semantic Versioning]: https://semver.org/
+
+The version does not need to be bumped and the changelog does not need
+to be updated for chores which do not affect users of this
+gem. Example: updating CI. Omitting these details helps keep the
+signal-to-noise ratio high for people upgrading the gem as these types
+of changes will not affect them.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,22 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+desc "Generate a new cop with a template"
+task :new_cop, [:cop] do |_task, args|
+  require "rubocop"
+
+  cop_name = args.fetch(:cop) do
+    warn "usage: bundle exec rake new_cop[Department/Name]"
+    exit!
+  end
+
+  generator = RuboCop::Cop::Generator.new(cop_name)
+
+  generator.write_source
+  generator.write_spec
+  generator.inject_require(root_file_path: "lib/ezcater_rubocop.rb")
+  generator.inject_config(config_file_path: "config/default.yml")
+
+  puts generator.todo
+end

--- a/config/default.yml
+++ b/config/default.yml
@@ -18,6 +18,14 @@ Ezcater/FeatureFlagNameValid:
   Description: "Enforce correct flag name format is being used."
   Enabled: true
 
+Ezcater/GraphQL/NotAuthorizedScalarField:
+  Description: 'Enforce the use of authorization for scalar GraphQL fields.'
+  Include:
+    - 'app/graphql/**/*.rb'
+    - 'packs/**/graphql/**/*.rb'
+  Enabled: false
+  VersionAdded: '6.1.0'
+
 Ezcater/RspecDotNotSelfDot:
   Description: 'Enforce ".<class method>" instead of "self.<class method>" for example group description.'
   Enabled: true

--- a/lib/ezcater_rubocop.rb
+++ b/lib/ezcater_rubocop.rb
@@ -19,6 +19,7 @@ RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
 require "rubocop/cop/ezcater/direct_env_check"
 require "rubocop/cop/ezcater/feature_flag_active"
 require "rubocop/cop/ezcater/feature_flag_name_valid"
+require "rubocop/cop/ezcater/graphql/not_authorized_scalar_field"
 require "rubocop/cop/ezcater/rails_configuration"
 require "rubocop/cop/ezcater/rails_env"
 require "rubocop/cop/ezcater/ruby_timeout"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.0.3"
+  VERSION = "6.1.0"
 end

--- a/lib/rubocop/cop/ezcater/graphql/not_authorized_scalar_field.rb
+++ b/lib/rubocop/cop/ezcater/graphql/not_authorized_scalar_field.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Ezcater
+      module GraphQL
+        # Enforces authorization for scalar GraphQL fields. It
+        # identifies scalar fields by matching against the standard
+        # [graphql-ruby scalar types] by default.
+        #
+        # [graphql-ruby scalar types]: https://graphql-ruby.org/type_definitions/scalars.html
+        #
+        # @safety
+        #   This cop is unable to autocorrect violations as decision making is
+        #   required on the part of the developer.
+        #
+        # @example AllowGuards: false (default)
+        #   # Requires that pundit authorization is used on scalar fields.
+        #   # @see https://graphql-ruby.org/authorization/pundit_integration.html#authorizing-fields
+        #
+        #   # bad
+        #   field :secret_name, String
+        #
+        #   # bad
+        #   field :secret_name, String
+        #
+        #   def secret_name
+        #     SecretNameGuard.new(context, object).guard do |person|
+        #       person.secret_name
+        #     end
+        #   end
+
+        #   # good
+        #   field :name, String, pundit_role: :owner
+        #
+        #   # good
+        #   field :name, String, pundit_role: :view, pundit_policy_class: "SecretNamePolicy"
+        #
+        # @example AllowGuards: true
+        #   # In addition to the pundit enforcement demonstrated in the previous
+        #   # example, guard-style authentication is allowed for scalar fields
+        #   # when a resolver is defined in the same class.
+        #
+        #   # bad
+        #   field :secret_name, String
+        #
+        #   def secret_name
+        #     "Rumplestiltskin"
+        #   end
+        #
+        #   # good
+        #   field :secret_name, String
+        #
+        #   def secret_name
+        #     SecretNameGuard.new(context, object).guard do |person|
+        #       person.secret_name
+        #     end
+        #   end
+        #
+        # @example AdditionalScalarTypes: [] (default)
+        #   # This option specifies additional scalar types for this cop to pay
+        #   # attention to. By default, this list is empty.
+        #
+        #   # bad
+        #   field :secret_id, ID
+        #
+        #   # good (i.e. the cop doesn't pay attention to UUID by default)
+        #   field :secret_id, UUID
+        #
+        # @example AdditionalScalarTypes: ["UUID"]
+        #   # This example adds UUID to the types to observe.
+        #
+        #   # bad
+        #   field :secret_id, UUID
+        #
+        #   # good
+        #   field :secret_id, pundit_role: owner
+        #
+        # @example IgnoredFieldNames: [] (default)
+        #   # This option specifies field names to ignore.
+        #
+        #   # bad (the field name is not in the ignore list)
+        #   field :id, ID
+        #
+        # @example IgnoredFieldNames: ["id"]
+        #   # This examples adds "id" to the list of ignored field names.
+        #
+        #   # good
+        #   field :id, ID
+        #
+        class NotAuthorizedScalarField < Base
+          include RuboCop::GraphQL::NodePattern
+
+          MSG = "Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized."
+
+          # https://graphql-ruby.org/type_definitions/scalars.html
+          STANDARD_SCALAR_TYPES = %w(BigInt Boolean Float Int ID ISO8601Date ISO8601DateTime ISO8601Duration JSON
+                                     String).freeze
+
+          # @!method field_type(node)
+          def_node_matcher :field_type, <<~PATTERN
+            (send nil? :field _ (:const nil? $_) ...)
+          PATTERN
+
+          # @!method field_with_body_type(node)
+          def_node_matcher :field_with_body_type, <<~PATTERN
+            (block (send nil? :field _ (:const nil? $_) ...) ...)
+          PATTERN
+
+          # @!method field_with_guard_in_body?(node)
+          def_node_matcher :field_with_guard_in_body?, <<~PATTERN
+            (block
+              (send nil? :field ...)
+              _?
+              (block
+                (send
+                  (send
+                    (:const ...) :new
+                    (send nil? :context)
+                    (send nil? :object)) :guard)
+                ...) ...)
+          PATTERN
+
+          # @!method field_with_pundit?(node)
+          def_node_matcher :field_with_pundit?, <<~PATTERN
+            (send nil? :field _ _ (hash <(pair (sym :pundit_role) _) ...>))
+          PATTERN
+
+          # @!method field_with_pundit_with_body?(node)
+          def_node_matcher :field_with_pundit_with_body?, <<~PATTERN
+            (block (send nil? :field _ _ (hash <(pair (sym :pundit_role) _) ...>)) ...)
+          PATTERN
+
+          # @!method contains_resolver_method_with_guard?(node)
+          def_node_search :contains_resolver_method_with_guard?, <<~PATTERN
+            (def %1
+              (args)
+              (block
+                (send
+                  (send
+                    (:const ...) :new
+                    (send nil? :context)
+                    (send nil? :object)) :guard)
+                ...) ...)
+          PATTERN
+
+          def on_class(node)
+            body = RuboCop::GraphQL::SchemaMember.new(node).body
+
+            each_field_node(body) do |field_node|
+              check_field_for_offense(field_node, node)
+            end
+          end
+
+          private
+
+          def allow_guards?
+            @_allow_guards ||= !!cop_config["AllowGuards"]
+          end
+
+          def check_field_for_offense(field, class_node)
+            return if field_with_pundit?(field.node) || field_with_pundit_with_body?(field.node)
+            return if ignored_field_names.include?(field.underscore_name)
+
+            type = field_type(field.node) || field_with_body_type(field.node)
+            return unless scalar_types.include?(type.to_s)
+
+            return if allow_guards? && (
+                        field_with_guard_in_body?(field.node) ||
+                        contains_resolver_method_with_guard?(class_node, field.underscore_name.to_sym)
+                      )
+
+            add_offense(field.node)
+          end
+
+          def each_field_node(body)
+            return unless body
+
+            body.each do |node|
+              yield RuboCop::GraphQL::Field.new(node) if field?(node)
+            end
+          end
+
+          def ignored_field_names
+            @_ignored_field_names ||= (cop_config["IgnoredFieldNames"] || []).to_set
+          end
+
+          def scalar_types
+            return @_scalar_types if defined?(@_scalar_types)
+
+            additional_scalar_types = cop_config["AdditionalScalarTypes"] || []
+            @_scalar_types = STANDARD_SCALAR_TYPES.to_set.merge(additional_scalar_types)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/ezcater/graphql/not_authorized_scalar_field_spec.rb
+++ b/spec/rubocop/cop/ezcater/graphql/not_authorized_scalar_field_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Ezcater::GraphQL::NotAuthorizedScalarField, :config do
+  describe "configured to not AllowGuards (default)" do
+    it "registers an offense on scalar fields when it does not detect `pundit_role` kwarg" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+        end
+      RUBY
+    end
+
+    it "registers an offense on scalar fields even when a guard is used in a resolver method" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+
+          def secret_name
+            PiiGuard.new(context, object).guard do |blah|
+              "Rumplestiltskin"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense when it detects the `pundit_role` kwarg on scalar fields" do
+      expect_no_offenses(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String, null: false, pundit_role: :owner, description: "PII"
+        end
+      RUBY
+    end
+
+    it "registers an offense on scalar fields with bodies when it does not detect `pundit_role` kwarg" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+            "Rumplestiltskin"
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense on scalar fields even when a guard is used in its body" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+            PiiGuard.new(context, object).guard do |blah|
+              "Rumplestiltskin"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense when it detects the `pundit_role` kwarg on scalar fields with bodies" do
+      expect_no_offenses(<<~RUBY)
+        class SomeGraphQLType
+          field :pii, String, null: false, pundit_role: :owner, description: "PII" do
+            "Rumplestiltskin"
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe "configured to AllowGuards" do
+    let(:cop_config) { { "AllowGuards" => true } }
+
+    it "registers an offense on scalar fields without authorization" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+        end
+      RUBY
+    end
+
+    it "does not register an offense if a guard is used in a resolver method" do
+      expect_no_offenses(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String
+
+          def secret_name
+            PiiGuard.new(context, object).guard do |blah|
+              "Rumplestiltskin"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense on scalar fields with bodies which lack authorization" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+            "Rumplestiltskin"
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense on scalar fields when a guard is used in its body" do
+      expect_no_offenses(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_name, String do
+            PiiGuard.new(context, object).guard do |blah|
+              "Rumplestiltskin"
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe "configured without AdditionalScalarTypes (default)" do
+    %w(BigInt Boolean Float Int ID ISO8601Date ISO8601DateTime ISO8601Duration JSON
+       String).each do |default_scalar_type|
+      it "registers an offense on #{default_scalar_type} fields which lack authorization" do
+        expect_offense(<<~RUBY)
+          class SomeGraphQLType
+            field :secret, #{default_scalar_type}
+            ^^^^^^^^^^^^^^^#{'^' * default_scalar_type.length} Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+          end
+        RUBY
+      end
+    end
+
+    it "does not register an offense on non-scalar fields which lack authorization" do
+      expect_no_offenses(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_cabinet, Cabinet
+        end
+      RUBY
+    end
+  end
+
+  describe "configured with AdditionalScalarTypes" do
+    let(:cop_config) { { "AdditionalScalarTypes" => %w(File Folio) } }
+
+    %w(BigInt Boolean Float Int ID ISO8601Date ISO8601DateTime ISO8601Duration JSON
+       String).each do |default_scalar_type|
+      it "registers an offense on #{default_scalar_type} fields which lack authorization" do
+        expect_offense(<<~RUBY)
+          class SomeGraphQLType
+            field :secret, #{default_scalar_type}
+            ^^^^^^^^^^^^^^^#{'^' * default_scalar_type.length} Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+          end
+        RUBY
+      end
+    end
+
+    %w(File Folio).each do |additional_scalar_type|
+      it "registers an offense on #{additional_scalar_type} fields which lack authorization" do
+        expect_offense(<<~RUBY)
+          class SomeGraphQLType
+            field :secret, #{additional_scalar_type}
+            ^^^^^^^^^^^^^^^#{'^' * additional_scalar_type.length} Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+          end
+        RUBY
+      end
+    end
+
+    it "does not register an offense on a non-scalar field which lacks authorization" do
+      expect_no_offenses(<<~RUBY)
+        class SomeGraphQLType
+          field :secret_cabinet, Cabinet
+        end
+      RUBY
+    end
+  end
+
+  describe "configured without IgnoredFieldNames (default)" do
+    it "registers an offense on a scalar field without authorization" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :id, ID
+          ^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+        end
+      RUBY
+    end
+  end
+
+  describe "configured with IgnoredFieldNames" do
+    let(:cop_config) { { "IgnoredFieldNames" => %w(id secret) } }
+
+    %w(id secret).each do |ignored_field_name|
+      it "doesn't register an offense scalar fields, such as #{ignored_field_name}, without authn with ignored names" do
+        expect_no_offenses(<<~RUBY)
+          class SomeGraphQLType
+            field :#{ignored_field_name}, ID
+          end
+        RUBY
+      end
+    end
+
+    it "registers an offense on a scalar fields without authorization whose name is not ignored" do
+      expect_offense(<<~RUBY)
+        class SomeGraphQLType
+          field :burn_after_reading, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ezcater/GraphQL/NotAuthorizedScalarFields: must be authorized.
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## What did we change?

This cop enforces the use of authorization for scalar GraphQL fields.

By default, it requires pundit and identifies all standard
graphql-ruby scalars as scalar values.

It can be configured to:
- Allow the "guard pattern" for authorization
- Identify additional types as scalars
- Ignore certain fields by name

### Development Changes

Adds a `new_cop` rake task which is helpful for generating new cops.

## Why are we doing this?

This cop can be helpful for finding GraphQL fields which lack adequate authorization. It only checks scalar fields, under the assumption that mutations and fields which reference object types should use more generalized authorization, which should be checked by future cops.

This cop is turned off by default so that application-owners can opt-in, minimizing disruption and providing an opportunity to identify and fix edge cases before making it mandatory.

This cop was the most complex one of the set to write as it needs to cover multiple mechanisms for handling authorization and multiple sets of syntax for defining resolvers. The other cops should be easier to write in the future and can likely follow this cop's example.

## How was it tested?
- [x] Specs
- [x] Locally
