### PR TITLE
Fix `FeatureFlagActive` to allow constants or dot method calls as first arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.0.3
+- Fix `FeatureFlagActive` cop so that it allows feature flag names to be constants and dot method calls in addition to strings.
+
 ## 6.0.2
 - Upgrade rubocop-rspec to v2.22.0 to use the new FactoryBot namespaces.
 - Fix the following wrong namespaces related to `FactoryBot`: `RSpec/FactoryBot/AttributeDefinedStatically`, `RSpec/FactoryBot/CreateList` and `RSpec/FactoryBot/FactoryClassName`.

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.0.2"
+  VERSION = "6.0.3"
 end

--- a/lib/rubocop/cop/ezcater/feature_flag_active.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_active.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   EzFF.active?("FlagName", identifiers: ["user:12345", "user:23456"])
       #   EzFF.active?(defined_flag_name_var, tracking_id: "brand:12345")
       #   EzFF.active?(@flag_name_ivar, tracking_id: "brand:12345")
-      #   EzFF.active?(CONTANT_NAME, tracking_id: "brand:12345")
+      #   EzFF.active?(CONSTANT_NAME, tracking_id: "brand:12345")
       #   EzFF.active?(config.flag_name, tracking_id: "brand:12345")
       #
       #   # bad

--- a/lib/rubocop/cop/ezcater/feature_flag_active.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_active.rb
@@ -20,6 +20,7 @@ module RuboCop
       #   EzFF.active?(defined_flag_name_var)
       #   EzFF.active?(@flag_name_ivar)
       #   EzFF.active?(:symbol_name, tracking_id: "brand:12345")
+      #   EzFF.active?(123, identifiers: ["user:12345"])
 
       class FeatureFlagActive < Cop
         MSG = "`EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`"

--- a/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
@@ -42,8 +42,32 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
         end
       end
 
+      context "with a constant instead of a flag name" do
+        let(:line) { %[#{constant_name}.active?(FLAG_VAR, identifiers: ["#{tracking_id}"])] }
+
+        it "does not report an offense" do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context "with a dot method call instead of a flag name" do
+        let(:line) { %[#{constant_name}.active?(config.flag_name, identifiers: ["#{tracking_id}"])] }
+
+        it "does not report an offense" do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
       context "with a symbol instead of a flag name" do
         let(:line) { %[#{constant_name}.active?(:my_flag_sym, identifiers: ["#{tracking_id}"])] }
+
+        it "reports an offense" do
+          expect(cop.messages).to match_array(first_params_msgs)
+        end
+      end
+
+      context "with an integer instead of a flag name" do
+        let(:line) { %[#{constant_name}.active?(13, identifiers: ["#{tracking_id}"])] }
 
         it "reports an offense" do
           expect(cop.messages).to match_array(first_params_msgs)


### PR DESCRIPTION
## What did we change?

- Fix `FeatureFlagActive` to allow constants or dot method calls as first arguments
- Add checks for symbols or integers as first arguments and throw violations in those instances

## Why are we doing this?

In trying to finally enable the `FeatureFlagActive` cop in `ez-rails`, we ran into a few false positive violations:
```
app/controllers/concerns/ez393_experiment_helper.rb:39:38: C: Ezcater/FeatureFlagActive: The first argument to EzFF.active? must be a string or predefined variable
      @_ez393_feature_flag_enabled = EzFF.active?(FEATURE_FLAG, tracking_id: TrackingId.read(cookies: cookies))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/cached_feature_flag.rb:68:5: C: Ezcater/FeatureFlagActive: The first argument to EzFF.active? must be a string or predefined variable
    EzFF.active?(feature_flag, **ff_args)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
packs/auth0/public/services/auth0/redirect.rb:29:7: C: Ezcater/FeatureFlagActive: The first argument to EzFF.active? must be a string or predefined variable
      EzFF.active?(AUTH0_ENABLED_FLAG, identifiers: [email])
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
packs/order_restrictions/app/services/order_restrictions/generic_validator/validator_instance.rb:64:38: C: Ezcater/FeatureFlagActive: The first argument to EzFF.active? must be a string or predefined variable
        config.raise_ff_name.nil? || EzFF.active?(config.raise_ff_name, tracking_id: order.uuid)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
packs/permissions/app/services/permissions/admin/okta_provider.rb:59:12: C: Ezcater/FeatureFlagActive: The first argument to EzFF.active? must be a string or predefined variable
        if EzFF.active?(SKIP_EXPIRATION_FEATURE_FLAG, identifiers: [user.email])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
packs/permissions/public/services/permissions/admin/access.rb:120:11: C: Ezcater/FeatureFlagActive: The first argument to EzFF.active? must be a string or predefined variable
          EzFF.active?(FEATURE_FLAG_NAME, identifiers: [user_email])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

These seem like they should be valid, so I adjusted the cop to be more lenient but still check of integers or symbols being incorrectly used.

## How was it tested?
- [x] Specs
- [ ] Locally
