### PR TITLE
CA-401 Lock rubocop_rspec below v2.28.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.1.1
+
+- Lock `rubocop-rspec` below `v2.28.0` to avoid an upstream namespacing issue.
+
 ## 6.1.0
 
 - Add `Ezcater/GraphQL/NotAuthorizedScalarField` Cop which enforces the use

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -55,5 +55,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop", ">= 1.16.0", "< 2.0"
   spec.add_runtime_dependency "rubocop-graphql", ">= 0.14.0", "< 1.0"
   spec.add_runtime_dependency "rubocop-rails", ">= 2.10.1", "< 3.0"
-  spec.add_runtime_dependency "rubocop-rspec", ">= 2.22.0", "< 3.0"
+  spec.add_runtime_dependency "rubocop-rspec", ">= 2.22.0", "< 2.28.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.1.0"
+  VERSION = "6.1.1"
 end


### PR DESCRIPTION
## What did we change?

This locks the rubocop_rspec gem below v2.28 to temporarily fix a regression caused by that issue.

## Why are we doing this?

[Slack](https://ezcater.slack.com/archives/CREPTH9LJ/p1712001323908889)

[rubocop_rspec v2.28.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.28.0) was released with a regression that is causing our gems to throw "Ambiguous cop name `RSpec/Rails/HttpStatus`" errors: 

![Screenshot 2024-04-02 at 12 44 30 PM](https://github.com/ezcater/ezcater_rubocop/assets/329575/cd8ef851-3102-4ca8-80be-15a8cec67441)

This temporary fix should unblock ezcater gem releases until a more permanent solution is available

## How was it tested?
- [ ] Specs
- [ ] Locally
