### PR TITLE
fix: Disabling the cop that enforces variable name for Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.1.2
+
+- Disable `Naming/RescuedExceptionsVariableName` so exception variable names are less restrictive.
+
+
 ## 6.1.1
 
 - Lock `rubocop-rspec` below `v2.28.0` to avoid an upstream namespacing issue.

--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -50,6 +50,9 @@ Naming/MethodParameterName:
     - ex
     - id
 
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
 Naming/VariableNumber:
   Enabled: false
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.1.1"
+  VERSION = "6.1.2"
 end


### PR DESCRIPTION
## What did we change?
Disabled the `Naming/RescuedExceptionsVariableName` cop

## Why are we doing this?
Single variable names were used heavily in the past due to screen constraints and memory sizes. Also because of math notations like `i, j, l` (remember C's `for (i = 1; i < 11; ++i)`? 
Ruby's greatest strength is readability, this change will allow devs to use a more significant name if desired and also keep `e` too for historical reasons, but mainly to not pigeon hole anyone to any specific variable name pattern.

## How was it tested?
- [ ] Specs
- [x] Locally
