### PR TITLE
Drop support for ruby 2.6 & 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,4 @@ workflows:
           matrix:
             parameters:
               # https://github.com/CircleCI-Public/cimg-ruby
-              ruby-version: ["2.7", "3.0", "3.1"]
+              ruby-version: ["3.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,4 @@ workflows:
           matrix:
             parameters:
               # https://github.com/CircleCI-Public/cimg-ruby
-              ruby-version: ["3.1"]
+              ruby-version: ["3.1", "3.2", "3.3"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 6.2.0
+
+- Drop support for ruby 2.6 & 3.0
+
 ## 6.1.2
 
 - Disable `Naming/RescuedExceptionsVariableName` so exception variable names are less restrictive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
-## 6.2.0
+## 7.0.0
 
 - Drop support for ruby 2.6 & 3.0
 

--- a/conf/rubocop_gem.yml
+++ b/conf/rubocop_gem.yml
@@ -2,7 +2,7 @@ inherit_from:
   - ../conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
   Exclude:
     - 'vendor/bundle/**/*'
     - 'gemfiles/vendor/**/*' 

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.executables << "circle_rubocop.rb"
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.2.0"
+  VERSION = "7.0.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "6.1.2"
+  VERSION = "6.2.0"
 end

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -4,7 +4,7 @@
 RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:ruby_version) { 2.6 }
+  let(:ruby_version) { 3.1 }
   let(:msgs) { [described_class::MSG] }
 
   it "accepts non-nested access" do


### PR DESCRIPTION
## What did we change?

We tried to bump the ruby version in another gem and the `TargetRubyVersion` in conf/rubocop_gem.yml was blocking requiring a supported version of ruby.  Rather than override locally, it felt like a good time to drop support for unsupported versions of ruby.

## How was it tested?
- [ ] Specs
- [ ] Locally
