### PR TITLE
refactor: rubocop for v1 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 7.1.0
+- Upgrade rubocop to v1 API (following guide [here](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html)) to stop deprecation warnings in rubocop >=1.67.
+
 ## 7.0.0
 
 - Drop support for ruby 2.6 & 3.0

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "7.0.0"
+  VERSION = "7.1.0"
 end

--- a/lib/rubocop/cop/ezcater/direct_env_check.rb
+++ b/lib/rubocop/cop/ezcater/direct_env_check.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   # bad
       #   enforce_foo! if ENV["FOO_ENFORCED"] == "true"
       #
-      class DirectEnvCheck < Cop
+      class DirectEnvCheck < Base
         MSG = <<~END_MESSAGE.split("\n").join(" ")
           Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `ENV`. Restricting
           environment variables references to be within application configuration makes it more obvious which env vars

--- a/lib/rubocop/cop/ezcater/direct_env_check.rb
+++ b/lib/rubocop/cop/ezcater/direct_env_check.rb
@@ -31,7 +31,7 @@ module RuboCop
 
         def on_const(node)
           env_ref(node) do
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/feature_flag_active.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_active.rb
@@ -57,11 +57,11 @@ module RuboCop
           return unless method_call_matcher(node)
 
           if first_param_bad(node)
-            add_offense(node, location: :expression, message: FIRST_PARAM_MSG)
+            add_offense(node.loc.expression, message: FIRST_PARAM_MSG)
           end
 
           if ezff_active_one_arg(node) || !args_matcher(node)
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/feature_flag_active.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_active.rb
@@ -22,7 +22,7 @@ module RuboCop
       #   EzFF.active?(:symbol_name, tracking_id: "brand:12345")
       #   EzFF.active?(123, identifiers: ["user:12345"])
 
-      class FeatureFlagActive < Cop
+      class FeatureFlagActive < Base
         MSG = "`EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`"
         FIRST_PARAM_MSG = "The first argument to `EzFF.active?` must be a string literal or a variable " \
         "or constant assigned to a string"

--- a/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
@@ -21,7 +21,7 @@ module RuboCop
       #   EzFF.at_100?("Foo::Bar && rm -rf * ")
       #   EzFF.active?("foo::bar", identifiers: ["user:1"])
       #   MY_FLAG="Foo:bar"
-      class FeatureFlagNameValid < Cop
+      class FeatureFlagNameValid < Base
         WHITESPACE = /\s/
         ISOLATED_COLON = /(?<!:):(?!:)/
         TRIPLE_COLON = /:::/

--- a/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
+++ b/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb
@@ -46,7 +46,7 @@ module RuboCop
           feature_flag_constant_assignment(node) do |const_name, flag_name|
             if const_name.end_with?("_FF", "_FLAG", "_FLAG_NAME", "_FEATURE_FLAG")
               errors = find_name_violations(flag_name)
-              add_offense(node, location: :expression, message: errors.join(", ")) if errors.any?
+              add_offense(node.loc.expression, message: errors.join(", ")) if errors.any?
             end
           end
         end
@@ -56,7 +56,7 @@ module RuboCop
 
           feature_flag_method_call(node) do |flag_name|
             errors = find_name_violations(flag_name)
-            add_offense(node, location: :expression, message: errors.join(", ")) if errors.any?
+            add_offense(node.loc.expression, message: errors.join(", ")) if errors.any?
           end
         end
 

--- a/lib/rubocop/cop/ezcater/rails_configuration.rb
+++ b/lib/rubocop/cop/ezcater/rails_configuration.rb
@@ -13,7 +13,7 @@ module RuboCop
 
         def on_send(node)
           rails_application_config(node) do
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
 

--- a/lib/rubocop/cop/ezcater/rails_configuration.rb
+++ b/lib/rubocop/cop/ezcater/rails_configuration.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     module Ezcater
       class RailsConfiguration < Base
+        extend RuboCop::Cop::AutoCorrector
+
         MSG = "Use `Rails.configuration` instead of `Rails.application.config`."
         RAILS_CONFIGURATION = "Rails.configuration"
 
@@ -13,13 +15,9 @@ module RuboCop
 
         def on_send(node)
           rails_application_config(node) do
-            add_offense(node.loc.expression, message: MSG)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, RAILS_CONFIGURATION)
+            add_offense(node.loc.expression, message: MSG) do |corrector|
+              corrector.replace(node.source_range, RAILS_CONFIGURATION)
+            end
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/rails_configuration.rb
+++ b/lib/rubocop/cop/ezcater/rails_configuration.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Ezcater
-      class RailsConfiguration < Cop
+      class RailsConfiguration < Base
         MSG = "Use `Rails.configuration` instead of `Rails.application.config`."
         RAILS_CONFIGURATION = "Rails.configuration"
 

--- a/lib/rubocop/cop/ezcater/rails_env.rb
+++ b/lib/rubocop/cop/ezcater/rails_env.rb
@@ -21,7 +21,7 @@ module RuboCop
       #   # bad
       #   enforce_foo! if ENV["RAILS_ENV"] == "production"
       #
-      class RailsEnv < Cop
+      class RailsEnv < Base
         MSG = <<~END_MESSAGE.split("\n").join(" ")
           Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that
           configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg

--- a/lib/rubocop/cop/ezcater/rails_env.rb
+++ b/lib/rubocop/cop/ezcater/rails_env.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         def on_send(node)
           rails_env(node) do
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
+++ b/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
@@ -15,6 +15,8 @@ module RuboCop
       #   ActiveRecord::Base.connection.execute("...")
       #
       class RailsTopLevelSqlExecute < Base
+        extend RuboCop::Cop::AutoCorrector
+
         MSG = <<~END_MESSAGE.split("\n").join(" ")
           Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations. The latter is
           redundant and can bypass safety checks.
@@ -26,19 +28,15 @@ module RuboCop
 
         def on_send(node)
           ar_connection_execute(node) do
-            add_offense(node.loc.expression, message: MSG)
-          end
-        end
+            add_offense(node.loc.expression, message: MSG) do |corrector|
+              range = Parser::Source::Range.new(
+                node.source_range.source_buffer,
+                node.source_range.begin_pos,
+                node.source_range.end_pos
+              )
 
-        def autocorrect(node)
-          lambda do |corrector|
-            range = Parser::Source::Range.new(
-              node.source_range.source_buffer,
-              node.source_range.begin_pos,
-              node.source_range.end_pos
-            )
-
-            corrector.replace(range, "execute(#{node.last_argument.source})")
+              corrector.replace(range, "execute(#{node.last_argument.source})")
+            end
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
+++ b/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # bad
       #   ActiveRecord::Base.connection.execute("...")
       #
-      class RailsTopLevelSqlExecute < Cop
+      class RailsTopLevelSqlExecute < Base
         MSG = <<~END_MESSAGE.split("\n").join(" ")
           Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations. The latter is
           redundant and can bypass safety checks.

--- a/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
+++ b/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def on_send(node)
           ar_connection_execute(node) do
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
 

--- a/lib/rubocop/cop/ezcater/require_custom_error.rb
+++ b/lib/rubocop/cop/ezcater/require_custom_error.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   raise OrderActionNotAllowed
 
-      class RequireCustomError < Cop
+      class RequireCustomError < Base
         MSG = "Use a custom error class that inherits from StandardError when raising an exception"
 
         def_node_matcher :raising_standard_or_argument_error,

--- a/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb
+++ b/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   # bad
       #   GraphQL::ExecutionError.new("An error occurred")
       #   GraphQL::ExecutionError.new("You can't access this", options: { status_code: 401 })
-      class RequireGqlErrorHelpers < Cop
+      class RequireGqlErrorHelpers < Base
         MSG = "Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly."
 
         def_node_matcher :graphql_const?, <<~PATTERN
@@ -29,7 +29,7 @@ module RuboCop
         def on_const(node)
           return unless graphql_const?(node)
 
-          add_offense(node, location: :expression, message: MSG)
+          add_offense(node.loc.expression, message: MSG)
         end
       end
     end

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -54,9 +54,9 @@ module RuboCop
 
           str_node = node.send_node.arguments[0]
           if str_node.value.match?(SELF_DOT_REGEXP)
-            add_offense(str_node, location: :expression, message: SELF_DOT_MSG)
+            add_offense(str_node.loc.expression, message: SELF_DOT_MSG)
           elsif str_node.value.match?(COLON_COLON_REGEXP)
-            add_offense(str_node, location: :expression, message: COLON_COLON_MSG)
+            add_offense(str_node.loc.expression, message: COLON_COLON_MSG)
           end
         end
 

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     ...
       #   end
 
-      class RspecDotNotSelfDot < Cop
+      class RspecDotNotSelfDot < Base
         include RuboCop::RSpec::Language
         extend RuboCop::RSpec::Language::NodePattern
 

--- a/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
+++ b/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb
@@ -26,6 +26,7 @@ module RuboCop
       class RspecDotNotSelfDot < Base
         include RuboCop::RSpec::Language
         extend RuboCop::RSpec::Language::NodePattern
+        extend RuboCop::Cop::AutoCorrector
 
         RSPEC_EXAMPLE_PREFIXES = ["", "x", "f"].freeze
         EXAMPLE_GROUP_IDENTIFIERS = (RSPEC_EXAMPLE_PREFIXES.map do |prefix|
@@ -53,19 +54,19 @@ module RuboCop
           return unless example_group?(node)
 
           str_node = node.send_node.arguments[0]
-          if str_node.value.match?(SELF_DOT_REGEXP)
-            add_offense(str_node.loc.expression, message: SELF_DOT_MSG)
-          elsif str_node.value.match?(COLON_COLON_REGEXP)
-            add_offense(str_node.loc.expression, message: COLON_COLON_MSG)
-          end
-        end
+          message = if str_node.value.match?(SELF_DOT_REGEXP)
+                      SELF_DOT_MSG
+                    elsif str_node.value.match?(COLON_COLON_REGEXP)
+                      COLON_COLON_MSG
+                    end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            experession_end = node.source.match?("::") ? 3 : 6
-            corrector.replace(Parser::Source::Range.new(node.source_range.source_buffer,
-                                                        node.source_range.begin_pos + 1,
-                                                        node.source_range.begin_pos + experession_end), ".")
+          if message
+            add_offense(str_node.loc.expression, message: message) do |corrector|
+              expression_end = str_node.source.match?("::") ? 3 : 6
+              corrector.replace(Parser::Source::Range.new(str_node.source_range.source_buffer,
+                                                          str_node.source_range.begin_pos + 1,
+                                                          str_node.source_range.begin_pos + expression_end), ".")
+            end
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
+++ b/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # bad
       #   expect(foo).to eq([1, 2, 3])
       #   expect(foo).to eq [1, 2, 3]
-      class RspecMatchOrderedArray < Cop
+      class RspecMatchOrderedArray < Base
         MATCH_ORDERED_ARRAY = "match_ordered_array"
         MSG = "Use the `match_ordered_array` matcher from ezcater_matchers gem "\
           "instead of `eq` when comparing collections"

--- a/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
+++ b/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
@@ -15,6 +15,8 @@ module RuboCop
       #   expect(foo).to eq([1, 2, 3])
       #   expect(foo).to eq [1, 2, 3]
       class RspecMatchOrderedArray < Base
+        extend RuboCop::Cop::AutoCorrector
+
         MATCH_ORDERED_ARRAY = "match_ordered_array"
         MSG = "Use the `match_ordered_array` matcher from ezcater_matchers gem "\
           "instead of `eq` when comparing collections"
@@ -25,20 +27,16 @@ module RuboCop
 
         def on_send(node)
           eq_array(node) do
-            add_offense(node.loc.expression, message: MSG)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(
-              Parser::Source::Range.new(
-                node.source_range.source_buffer,
-                node.source_range.begin_pos,
-                node.source_range.begin_pos + 2
-              ),
-              MATCH_ORDERED_ARRAY
-            )
+            add_offense(node.loc.expression, message: MSG) do |corrector|
+              corrector.replace(
+                Parser::Source::Range.new(
+                  node.source_range.source_buffer,
+                  node.source_range.begin_pos,
+                  node.source_range.begin_pos + 2
+                ),
+                MATCH_ORDERED_ARRAY
+              )
+            end
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
+++ b/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         def on_send(node)
           eq_array(node) do
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
 

--- a/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
@@ -39,8 +39,7 @@ module RuboCop
 
           # Finish tree navigation to full line for highlighting
           match_node = match_node.parent while match_node.parent
-          add_offense(match_node,
-                      location: :expression,
+          add_offense(match_node.loc.expression,
                       message: format(MSG, node_source: node.source))
         end
 

--- a/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   # bad
       #   allow(Browser).to receive...
       #   allow(EzBrowser).to receive...
-      class RspecRequireBrowserMock < Cop
+      class RspecRequireBrowserMock < Base
         MSG = "Use the mocks provided by `BrowserHelpers` instead of mocking `%<node_source>s`"
 
         def_node_matcher :browser_const?, <<~PATTERN

--- a/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
@@ -35,7 +35,7 @@ module RuboCop
 
           # Finish tree navigation to full line for highlighting
           match_node = match_node.parent while match_node.parent
-          add_offense(match_node, location: :expression)
+          add_offense(match_node.loc.expression)
         end
 
         private

--- a/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   allow(FeatureFlag).to receive(:is_active?).and_return(true)
       #   allow(FeatureFlag).to receive(:is_active?).with("MyFeatureFlag").and_return(true)
       #   allow(FeatureFlag).to receive(:is_active?).with("MyFeatureFlag", user: current_user).and_return(true)
-      class RspecRequireFeatureFlagMock < Cop
+      class RspecRequireFeatureFlagMock < Base
         MSG = "Use the `mock_feature_flag` helper instead of mocking `allow(FeatureFlag)`"
 
         def_node_matcher :feature_flag_const?, <<~PATTERN

--- a/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb
@@ -29,8 +29,7 @@ module RuboCop
         def on_send(node)
           return if !response_status_assertion(node) && !response_code_assertion(node)
 
-          add_offense(node,
-                      location: :expression,
+          add_offense(node.loc.expression,
                       message: format(MSG, node_source: node.source))
         end
       end

--- a/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb
+++ b/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # bad
       #   expect(response.code).to eq 201
       #   expect(response.code).to eq 400
-      class RspecRequireHttpStatusMatcher < Cop
+      class RspecRequireHttpStatusMatcher < Base
         MSG = "Use the `have_http_status` matcher, like `expect(response).to have_http_status :bad_request`, "\
           "rather than `%<node_source>s`"
 

--- a/lib/rubocop/cop/ezcater/ruby_timeout.rb
+++ b/lib/rubocop/cop/ezcater/ruby_timeout.rb
@@ -17,7 +17,7 @@ module RuboCop
       #     ...
       #   end
       #
-      class RubyTimeout < Cop
+      class RubyTimeout < Base
         MSG = <<~END_MESSAGE.split("\n").join(" ")
           `Timeout.timeout` is unsafe. Find an alternative to achieve the same goal.
            Ex. Use the timeout capabilities of a networking library.

--- a/lib/rubocop/cop/ezcater/ruby_timeout.rb
+++ b/lib/rubocop/cop/ezcater/ruby_timeout.rb
@@ -30,7 +30,7 @@ module RuboCop
 
         def on_send(node)
           timeout(node) do
-            add_offense(node, location: :expression, message: MSG)
+            add_offense(node.loc.expression, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -33,7 +33,7 @@ module RuboCop
           match_node = node
           # walk to outermost access node
           match_node = match_node.parent while access_node?(match_node.parent)
-          add_offense(match_node, location: :expression, message: MSG)
+          add_offense(match_node.loc.expression, message: MSG)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/ezcater/style_dig.rb
+++ b/lib/rubocop/cop/ezcater/style_dig.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   my_hash['foo'] && my_hash['foo']['bar']
       #   my_array[0][1]
 
-      class StyleDig < Cop
+      class StyleDig < Base
         extend TargetRubyVersion
 
         minimum_target_ruby_version 2.3

--- a/spec/rubocop/cop/ezcater/direct_env_check_spec.rb
+++ b/spec/rubocop/cop/ezcater/direct_env_check_spec.rb
@@ -1,38 +1,31 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::DirectEnvCheck, :config do
-  subject(:cop) { described_class.new(config) }
-
   it "blocks plain ENV references" do
-    source = "ENV"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["ENV"])
-    expect(cop.messages).to match_array([described_class::MSG])
+    expect_offense <<~RUBY
+      ENV
+      ^^^ Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `ENV`. Restricting environment variables references to be within application configuration makes it more obvious which env vars an application relies upon. https://ezcater.atlassian.net/wiki/x/ZIChNg
+    RUBY
   end
 
   it "blocks ENV for interpolated string values" do
-    source = %q(foo("#{ENV}-bar")) # rubocop:disable Lint/InterpolationCheck
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["ENV"])
-    expect(cop.messages).to match_array([described_class::MSG])
+    expect_offense <<~'RUBY'
+      foo("#{ENV}-bar")
+             ^^^ Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `ENV`. Restricting environment variables references to be within application configuration makes it more obvious which env vars an application relies upon. https://ezcater.atlassian.net/wiki/x/ZIChNg
+    RUBY
   end
 
   it "blocks key retrieval" do
-    source = 'ENV["FOO"]'
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["ENV"])
-    expect(cop.messages).to match_array([described_class::MSG])
+    expect_offense <<~RUBY
+      ENV["FOO"]
+      ^^^ Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `ENV`. Restricting environment variables references to be within application configuration makes it more obvious which env vars an application relies upon. https://ezcater.atlassian.net/wiki/x/ZIChNg
+    RUBY
   end
 
   it "blocks key retrieval with equality checks" do
-    source = 'ENV["FOO"] == "true"'
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["ENV"])
-    expect(cop.messages).to match_array([described_class::MSG])
+    expect_offense <<~RUBY
+      ENV["FOO"] == "true"
+      ^^^ Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `ENV`. Restricting environment variables references to be within application configuration makes it more obvious which env vars an application relies upon. https://ezcater.atlassian.net/wiki/x/ZIChNg
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
@@ -50,22 +50,18 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
 
       context "with a symbol instead of a flag name" do
         it "reports an offense" do
-          dynamic_highlight_width = "^" * (constant_name.size + tracking_id.size)
-
-          expect_offense <<~RUBY
+          expect_offense <<~RUBY, constant_name: constant_name, tracking_id: tracking_id
             #{constant_name}.active?(:my_flag_sym, identifiers: ["#{tracking_id}"])
-            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The first argument to `EzFF.active?` must be a string literal or a variable or constant assigned to a string
+            ^{constant_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{tracking_id}^^^ The first argument to `EzFF.active?` must be a string literal or a variable or constant assigned to a string
           RUBY
         end
       end
 
       context "with an integer instead of a flag name" do
         it "reports an offense" do
-          dynamic_highlight_width = "^" * (constant_name.size + tracking_id.size)
-
-          expect_offense <<~RUBY
+          expect_offense <<~RUBY, constant_name: constant_name, tracking_id: tracking_id
             #{constant_name}.active?(13, identifiers: ["#{tracking_id}"])
-            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The first argument to `EzFF.active?` must be a string literal or a variable or constant assigned to a string
+            ^{constant_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{tracking_id}^^^ The first argument to `EzFF.active?` must be a string literal or a variable or constant assigned to a string
           RUBY
         end
       end
@@ -80,22 +76,18 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
 
       context "with unexpected keyword args" do
         it "reports an offense" do
-          dynamic_highlight_width = "^" * (constant_name.size + tracking_id.size)
-
-          expect_offense <<~RUBY
+          expect_offense <<~RUBY, constant_name: constant_name, tracking_id: tracking_id
             #{constant_name}.active?("FakeFlagName", bad_arg: ["#{tracking_id}"])
-            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`
+            ^{constant_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{tracking_id}^^^ `EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`
           RUBY
         end
       end
 
       context "with no keyword args" do
         it "reports an offense" do
-          dynamic_highlight_width = "^" * constant_name.size
-
-          expect_offense <<~RUBY
+          expect_offense <<~RUBY, constant_name: constant_name
             #{constant_name}.active?("FakeFlagName")
-            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^ `EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`
+            ^{constant_name}^^^^^^^^^^^^^^^^^^^^^^^^ `EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`
           RUBY
         end
       end

--- a/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_active_spec.rb
@@ -1,100 +1,102 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
-  subject(:cop) { described_class.new(config) }
-
-  let(:flag_name) { "FeatureFlag #{rand(100)}" }
   let(:tracking_id) { generate_tracking_id }
-
-  let(:msgs) { [described_class::MSG] }
-  let(:first_params_msgs) { [described_class::FIRST_PARAM_MSG] }
-
-  before { inspect_source(line) }
 
   %w(EzcaterFeatureFlag EzFF ::EzFF ::EzcaterFeatureFlag).each do |constant_name|
     describe "calling #{constant_name}.active?" do
       context "with a tracking_id" do
-        let(:line) { %[#{constant_name}.active?("#{flag_name}", tracking_id: "#{tracking_id}")] }
-
         it "does not report an offense" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses <<~RUBY
+            #{constant_name}.active?("FakeFlagName", tracking_id: "#{tracking_id}")
+          RUBY
         end
       end
 
       context "with a variable instead of a flag name" do
-        let(:line) do
-          %[def evaluate(my_flag_name_var)
-            #{constant_name}.active?(my_flag_name_var, identifiers: ["#{tracking_id}"])
-          end]
-        end
-
         it "does not report an offense" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses <<~RUBY
+            def evaluate(my_flag_name_var)
+              #{constant_name}.active?(my_flag_name_var, identifiers: ["#{tracking_id}"])
+            end
+          RUBY
         end
       end
 
       context "with an instance variable instead of a flag name" do
-        let(:line) { %[#{constant_name}.active?(@flag_ivar, identifiers: ["#{tracking_id}"])] }
-
         it "does not report an offense" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses <<~RUBY
+            #{constant_name}.active?(@flag_ivar, identifiers: ["#{tracking_id}"])
+          RUBY
         end
       end
 
       context "with a constant instead of a flag name" do
-        let(:line) { %[#{constant_name}.active?(FLAG_VAR, identifiers: ["#{tracking_id}"])] }
-
         it "does not report an offense" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses <<~RUBY
+            FLAG_VAR = "FAKE_FLAG_NAME"
+            #{constant_name}.active?(FLAG_VAR, identifiers: ["#{tracking_id}"])
+          RUBY
         end
       end
 
       context "with a dot method call instead of a flag name" do
-        let(:line) { %[#{constant_name}.active?(config.flag_name, identifiers: ["#{tracking_id}"])] }
-
         it "does not report an offense" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses <<~RUBY
+            #{constant_name}.active?(config.flag_name, identifiers: ["#{tracking_id}"])
+          RUBY
         end
       end
 
       context "with a symbol instead of a flag name" do
-        let(:line) { %[#{constant_name}.active?(:my_flag_sym, identifiers: ["#{tracking_id}"])] }
-
         it "reports an offense" do
-          expect(cop.messages).to match_array(first_params_msgs)
+          dynamic_highlight_width = "^" * (constant_name.size + tracking_id.size)
+
+          expect_offense <<~RUBY
+            #{constant_name}.active?(:my_flag_sym, identifiers: ["#{tracking_id}"])
+            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The first argument to `EzFF.active?` must be a string literal or a variable or constant assigned to a string
+          RUBY
         end
       end
 
       context "with an integer instead of a flag name" do
-        let(:line) { %[#{constant_name}.active?(13, identifiers: ["#{tracking_id}"])] }
-
         it "reports an offense" do
-          expect(cop.messages).to match_array(first_params_msgs)
+          dynamic_highlight_width = "^" * (constant_name.size + tracking_id.size)
+
+          expect_offense <<~RUBY
+            #{constant_name}.active?(13, identifiers: ["#{tracking_id}"])
+            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The first argument to `EzFF.active?` must be a string literal or a variable or constant assigned to a string
+          RUBY
         end
       end
 
       context "with an identifiers array" do
-        let(:line) { %[#{constant_name}.active?("#{flag_name}", identifiers: ["#{tracking_id}"])] }
-
         it "does not report an offense" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses <<~RUBY
+            #{constant_name}.active?("FakeFlagName", identifiers: ["#{tracking_id}"])
+          RUBY
         end
       end
 
       context "with unexpected keyword args" do
-        let(:line) { %[#{constant_name}.active?("#{flag_name}", bad_arg: ["#{tracking_id}"])] }
-
         it "reports an offense" do
-          expect(cop.messages).to match_array(msgs)
+          dynamic_highlight_width = "^" * (constant_name.size + tracking_id.size)
+
+          expect_offense <<~RUBY
+            #{constant_name}.active?("FakeFlagName", bad_arg: ["#{tracking_id}"])
+            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`
+          RUBY
         end
       end
 
       context "with no keyword args" do
-        let(:line) { %[#{constant_name}.active?("#{flag_name}")] }
-
         it "reports an offense" do
-          expect(cop.messages).to match_array(msgs)
+          dynamic_highlight_width = "^" * constant_name.size
+
+          expect_offense <<~RUBY
+            #{constant_name}.active?("FakeFlagName")
+            #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^ `EzFF.active?` must be called with at least one of `tracking_id` or `identifiers`
+          RUBY
         end
       end
     end
@@ -102,24 +104,20 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagActive, :config do
 
   context "other lines that parse to use `send` in the AST don't get caught" do
     context "require" do
-      let(:line) { 'require "bar"' }
-
       it "reports nothing" do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses <<~RUBY
+          require "bar"
+        RUBY
       end
     end
 
     context "config blocks" do
-      let(:line) do
-        <<-RUBY
-        Configuration.config do |config|
-          config.foo = true
-        end
-        RUBY
-      end
-
       it "reports nothing" do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses <<~RUBY
+          Configuration.config do |config|
+            config.foo = true
+          end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
@@ -16,35 +16,27 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
 
         context "with an invalid feature flag name: flag1" do
           it "reports an offense for titlecase" do
-            dynamic_highlight_width = "^" * suffix.size
-
-            expect_offense <<~RUBY
+            expect_offense <<~RUBY, suffix: suffix
               SOMETHING#{suffix} = "flag1"
-              #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^ Feature flag names must use titlecase for each segment.
+              ^^^^^^^^^^{suffix}^^^^^^^^^^ Feature flag names must use titlecase for each segment.
             RUBY
           end
         end
 
         context "with an invalid feature flag name: Foo:bar" do
-          let(:line) { %(SOMETHING#{suffix} = "Foo:bar") }
-
           it "reports an offense for single colon use and titlecase" do
-            dynamic_highlight_width = "^" * suffix.size
-
-            expect_offense <<~RUBY
+            expect_offense <<~RUBY, suffix: suffix
               SOMETHING#{suffix} = "Foo:bar"
-              #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^ Feature flag names must use double colons (::) as namespace separators., Feature flag names must use titlecase for each segment.
+              ^^^^^^^^^^{suffix}^^^^^^^^^^^^ Feature flag names must use double colons (::) as namespace separators., Feature flag names must use titlecase for each segment.
             RUBY
           end
         end
 
         context "with an invalid feature flag name: Foo:::Bar " do
           it "reports an offense for triple colon use and whitespace" do
-            dynamic_highlight_width = "^" * suffix.size
-
-            expect_offense <<~RUBY
+            expect_offense <<~RUBY, suffix: suffix
               SOMETHING#{suffix} = "Foo :::B%ar"
-              #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^ Feature flag names must not contain whitespace., Feature flag names must use double colons (::) as namespace separators., Feature flag names must only contain alphanumeric characters and colons., Feature flag names must use titlecase for each segment.
+              ^^^^^^^^^^{suffix}^^^^^^^^^^^^^^^^ Feature flag names must not contain whitespace., Feature flag names must use double colons (::) as namespace separators., Feature flag names must only contain alphanumeric characters and colons., Feature flag names must use titlecase for each segment.
             RUBY
           end
         end
@@ -65,11 +57,9 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
 
         context "with an invalid feature flag name" do
           it "reports an offense" do
-            dynamic_highlight_width = "^" * (klass_name.size + method_name.size)
-
-            expect_offense <<~RUBY
+            expect_offense <<~RUBY, klass_name: klass_name, method_name: method_name
               #{klass_name}.#{method_name}("Foo:bar")
-              #{dynamic_highlight_width}^^^^^^^^^^^^ Feature flag names must use double colons (::) as namespace separators., Feature flag names must use titlecase for each segment.
+              ^{klass_name}^^{method_name}^^^^^^^^^^^ Feature flag names must use double colons (::) as namespace separators., Feature flag names must use titlecase for each segment.
             RUBY
           end
 

--- a/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
+++ b/spec/rubocop/cop/ezcater/feature_flag_name_valid_spec.rb
@@ -1,28 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
-  subject(:cop) { described_class.new(config) }
-
-  before { inspect_source(line) }
-
   describe "assignment to a constant" do
     %w(_FF _FLAG _FLAG_NAME _FEATURE_FLAG).each do |suffix|
       describe "assignment to a constant ending in #{suffix}" do
         %w(Flag1 Foo Foo::Bar Foo::Bar::Baz).each do |valid_flag_name|
           context "with a valid feature flag name: #{valid_flag_name}" do
-            let(:line) { %(SOMETHING#{suffix} = #{valid_flag_name}) }
-
             it "does not report an offense" do
-              expect(cop.offenses).to be_empty
+              expect_no_offenses <<~RUBY
+                SOMETHING#{suffix} = #{valid_flag_name}
+              RUBY
             end
           end
         end
 
         context "with an invalid feature flag name: flag1" do
-          let(:line) { %(SOMETHING#{suffix} = "flag1") }
-
           it "reports an offense for titlecase" do
-            expect(cop.messages).to match_array(["Feature flag names must use titlecase for each segment."])
+            dynamic_highlight_width = "^" * suffix.size
+
+            expect_offense <<~RUBY
+              SOMETHING#{suffix} = "flag1"
+              #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^ Feature flag names must use titlecase for each segment.
+            RUBY
           end
         end
 
@@ -30,27 +29,23 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
           let(:line) { %(SOMETHING#{suffix} = "Foo:bar") }
 
           it "reports an offense for single colon use and titlecase" do
-            expect(cop.messages).to match_array(
-              [
-                "Feature flag names must use double colons (::) as namespace separators., " \
-                "Feature flag names must use titlecase for each segment.",
-              ]
-            )
+            dynamic_highlight_width = "^" * suffix.size
+
+            expect_offense <<~RUBY
+              SOMETHING#{suffix} = "Foo:bar"
+              #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^ Feature flag names must use double colons (::) as namespace separators., Feature flag names must use titlecase for each segment.
+            RUBY
           end
         end
 
         context "with an invalid feature flag name: Foo:::Bar " do
-          let(:line) { %(SOMETHING#{suffix} = "Foo :::B%ar") }
-
           it "reports an offense for triple colon use and whitespace" do
-            expect(cop.messages).to match_array(
-              [
-                "Feature flag names must not contain whitespace., " \
-                "Feature flag names must use double colons (::) as namespace separators., " \
-                "Feature flag names must only contain alphanumeric characters and colons., " \
-                "Feature flag names must use titlecase for each segment.",
-              ]
-            )
+            dynamic_highlight_width = "^" * suffix.size
+
+            expect_offense <<~RUBY
+              SOMETHING#{suffix} = "Foo :::B%ar"
+              #{dynamic_highlight_width}^^^^^^^^^^^^^^^^^^^^^^^^^ Feature flag names must not contain whitespace., Feature flag names must use double colons (::) as namespace separators., Feature flag names must only contain alphanumeric characters and colons., Feature flag names must use titlecase for each segment.
+            RUBY
           end
         end
       end
@@ -61,30 +56,28 @@ RSpec.describe RuboCop::Cop::Ezcater::FeatureFlagNameValid, :config do
     %w(active? at_100? random_sample_active?).each do |method_name|
       describe "method call to #{klass_name}.#{method_name}" do
         context "with a valid feature flag name" do
-          let(:line) { %[#{klass_name}.#{method_name}("Foo::Bar", tracking_id: 1234)] }
-
           it "does not report an offense" do
-            expect(cop.offenses).to be_empty
+            expect_no_offenses <<~RUBY
+              #{klass_name}.#{method_name}("Foo::Bar", tracking_id: "1234")
+            RUBY
           end
         end
 
         context "with an invalid feature flag name" do
-          let(:line) { %[#{klass_name}.#{method_name}("Foo:bar")] }
-
           it "reports an offense" do
-            expect(cop.messages).to match_array(
-              [
-                "Feature flag names must use double colons (::) as namespace separators., " \
-                "Feature flag names must use titlecase for each segment.",
-              ]
-            )
+            dynamic_highlight_width = "^" * (klass_name.size + method_name.size)
+
+            expect_offense <<~RUBY
+              #{klass_name}.#{method_name}("Foo:bar")
+              #{dynamic_highlight_width}^^^^^^^^^^^^ Feature flag names must use double colons (::) as namespace separators., Feature flag names must use titlecase for each segment.
+            RUBY
           end
 
           context "without a tracking id" do
-            let(:line) { %[#{klass_name}.#{method_name}("Foobar")] }
-
             it "does not report an offense" do
-              expect(cop.offenses).to be_empty
+              expect_no_offenses <<~RUBY
+                #{klass_name}.#{method_name}("Foobar")
+              RUBY
             end
           end
         end

--- a/spec/rubocop/cop/ezcater/rails_configuration_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_configuration_spec.rb
@@ -1,22 +1,20 @@
-# encoding utf-8
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Ezcater::RailsConfiguration do
-  subject(:cop) { described_class.new }
-
-  let(:msgs) { ["Ezcater/RailsConfiguration: #{described_class::MSG}"] }
-
+RSpec.describe RuboCop::Cop::Ezcater::RailsConfiguration, :config do
   it "accepts Rails.configuration" do
-    source = "Rails.configuration.foobar"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      Rails.configuration.foobar
+    RUBY
   end
 
   it "corrects Rails.application.config" do
-    source = "Rails.application.config.foobar"
-    inspect_source(source)
-    expect(cop.highlights).to match_array(["Rails.application.config"])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("Rails.configuration.foobar")
+    expect_offense <<~RUBY
+      Rails.application.config.foobar
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Use `Rails.configuration` instead of `Rails.application.config`.
+    RUBY
+
+    expect_correction <<~RUBY
+      Rails.configuration.foobar
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/rails_env_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_env_spec.rb
@@ -20,11 +20,9 @@ RSpec.describe RuboCop::Cop::Ezcater::RailsEnv, :config do
     staging
   ).each do |environment_name|
     it "blocks specific env check '#{environment_name}' via Rails.env" do
-      dynamic_highlight_width = "^" * environment_name.size
-
-      expect_offense <<~RUBY
+      expect_offense <<~RUBY, environment_name: environment_name
         Rails.env.#{environment_name}?
-        ^^^^^^^^^^^#{dynamic_highlight_width} Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg
+        ^^^^^^^^^^^{environment_name}^ Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg
       RUBY
       expect_no_corrections
     end

--- a/spec/rubocop/cop/ezcater/rails_env_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_env_spec.rb
@@ -1,48 +1,39 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::RailsEnv, :config do
-  subject(:cop) { described_class.new(config) }
-
   it "allows plain Rails.env references" do
-    source = "Rails.env"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
-    expect(cop.highlights).to be_empty
+    expect_no_offenses <<~RUBY
+      Rails.env
+    RUBY
   end
 
   it "allows Rails.env for interpolated string values" do
-    source = %q(foo("#{Rails.env}-bar")) # rubocop:disable Lint/InterpolationCheck
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
-    expect(cop.highlights).to be_empty
+    expect_no_offenses <<~'RUBY'
+      foo("#{Rails.env}-bar")
+    RUBY
   end
 
-  it "blocks specific env checks via Rails.env" do
-    source = "Rails.env.development?"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array([described_class::MSG])
+  %w(
+    development
+    foo
+    production
+    staging
+  ).each do |environment_name|
+    it "blocks specific env check '#{environment_name}' via Rails.env" do
+      dynamic_highlight_width = "^" * environment_name.size
 
-    %w(production staging foo).each do |env_str|
-      inspect_source("Rails.env.#{env_str}?")
-      expect(cop.offenses).not_to be_empty
+      expect_offense <<~RUBY
+        Rails.env.#{environment_name}?
+        ^^^^^^^^^^^#{dynamic_highlight_width} Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg
+      RUBY
+      expect_no_corrections
     end
   end
 
   it "blocks equality checks" do
-    source = "Rails.env == 'development'"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array([source])
-  end
-
-  it "does not support autocorrect" do
-    source = "Rails.env.development?"
-    inspect_source(source)
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array([described_class::MSG])
-    expect(autocorrect_source(source)).to eq(source)
+    expect_offense <<~RUBY
+      Rails.env == 'development'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `Rails.configuration.x.<foo>` for env-backed configuration instead of inspecting `Rails.env`, so that configuration is more centralized and gives finer control. https://ezcater.atlassian.net/wiki/x/ZIChNg
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/rails_top_level_sql_execute_spec.rb
+++ b/spec/rubocop/cop/ezcater/rails_top_level_sql_execute_spec.rb
@@ -1,37 +1,27 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Ezcater::RailsTopLevelSqlExecute do
-  subject(:cop) { described_class.new }
-
-  let(:msgs) { ["Ezcater/RailsTopLevelSqlExecute: #{described_class::MSG}"] }
-
+RSpec.describe RuboCop::Cop::Ezcater::RailsTopLevelSqlExecute, :config do
   it "accepts `execute`" do
-    source = "execute('SELECT * FROM foo')"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      execute('SELECT * FROM foo')
+    RUBY
   end
 
   it "detects `ActiveRecord::Base.connection.execute`" do
-    source = "ActiveRecord::Base.connection.execute('SELECT * FROM foo')"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense <<~RUBY
+      ActiveRecord::Base.connection.execute('SELECT * FROM foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations. The latter is redundant and can bypass safety checks.
+    RUBY
+
+    expect_correction <<~RUBY
+      execute('SELECT * FROM foo')
+    RUBY
   end
 
   it "detects `ActiveRecord::Base.connection.execute` with non-string arguments" do
-    source = "ActiveRecord::Base.connection.execute(foo_bar)"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
-  end
-
-  it "supports autocorrect" do
-    source = "ActiveRecord::Base.connection.execute('SELECT * FROM foo')"
-    inspect_source(source)
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("execute('SELECT * FROM foo')")
+    expect_offense <<~RUBY
+      ActiveRecord::Base.connection.execute(foo_bar)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `execute` instead of `ActiveRecord::Base.connection.execute` in migrations. The latter is redundant and can bypass safety checks.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/require_custom_error_spec.rb
+++ b/spec/rubocop/cop/ezcater/require_custom_error_spec.rb
@@ -1,28 +1,51 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::RequireCustomError, :config do
-  subject(:cop) { described_class.new(config) }
+  it "registers offense for raising StandardError class without message argument" do
+    expect_offense <<~RUBY
+      raise StandardError
+      ^^^^^^^^^^^^^^^^^^^ Use a custom error class that inherits from StandardError when raising an exception
+    RUBY
+  end
 
-  it "requires a custom error when raising Standard or Argument error" do
-    offensive_uses = [
-      "raise StandardError",
-      "raise ArgumentError",
-      "raise ArgumentError, 'expected string'",
-      "raise StandardError.new('expected string')",
-    ]
+  it "registers offense for raising StandardError class with message argument" do
+    expect_offense <<~RUBY
+      raise StandardError, "expected string"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a custom error class that inherits from StandardError when raising an exception
+    RUBY
+  end
 
-    offensive_uses.each do |offensive_use|
-      inspect_source(offensive_use)
+  it "registers offense for raising StandardError instance" do
+    expect_offense <<~RUBY
+      raise StandardError.new("expected string")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a custom error class that inherits from StandardError when raising an exception
+    RUBY
+  end
 
-      expect(cop.offenses).not_to be_empty
-      expect(cop.messages).to match_array(described_class::MSG)
-    end
+  it "registers offense for raising ArgumentError class without message argument" do
+    expect_offense <<~RUBY
+      raise ArgumentError
+      ^^^^^^^^^^^^^^^^^^^ Use a custom error class that inherits from StandardError when raising an exception
+    RUBY
+  end
+
+  it "registers offense for raising ArgumentError class with message argument" do
+    expect_offense <<~RUBY
+      raise ArgumentError, "expected string"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a custom error class that inherits from StandardError when raising an exception
+    RUBY
+  end
+
+  it "registers offense for raising ArgumentError instance" do
+    expect_offense <<~RUBY
+      raise ArgumentError.new("expected string")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a custom error class that inherits from StandardError when raising an exception
+    RUBY
   end
 
   it "allows raising custom errors" do
-    inspect_source("raise MyCustomError")
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      raise MyCustomError
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
+++ b/spec/rubocop/cop/ezcater/require_gql_error_helpers_spec.rb
@@ -1,27 +1,20 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe RuboCop::Cop::Ezcater::RequireGqlErrorHelpers, :config do
-  subject(:cop) { described_class.new }
-
-  let(:error_message) { "Ezcater/RequireGqlErrorHelpers: #{described_class::MSG}" }
-  let(:expected_source) { "GraphQL::ExecutionError" }
-
   context "when attempting to directly use GraphQL::ExecutionError" do
     it "registers an offense" do
-      source = "GraphQL::ExecutionError.new(\"An error occurred\")"
-      inspect_source(source)
-      expect(cop.messages).to match_array([error_message])
-      expect(cop.highlights).to match_array([expected_source])
+      expect_offense <<~RUBY
+        GraphQL::ExecutionError.new("An error occurred")
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.
+      RUBY
     end
 
     context "and additional options are provided" do
       it "registers an offense" do
-        source = "GraphQL::ExecutionError.new(\"An error occurred\", options: { status_code: 401 })"
-        inspect_source(source)
-        expect(cop.messages).to match_array([error_message])
-        expect(cop.highlights).to match_array([expected_source])
+        expect_offense <<~RUBY
+          GraphQL::ExecutionError.new("An error occurred", extensions: { "statusCode" => 401 })
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use the helpers provided by `GQLErrors` instead of raising `GraphQL::ExecutionError` directly.
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
@@ -3,11 +3,9 @@
 RSpec.describe RuboCop::Cop::Ezcater::RspecDotNotSelfDot, :config do
   described_class::EXAMPLE_GROUP_IDENTIFIERS.each do |name|
     it "corrects #{name} with `self.class_method`" do
-      left_pad_for_highlight = " " * name.size
-
-      expect_offense <<~RUBY
+      expect_offense <<~RUBY, name: name
         #{name} "self.class_method" do; end
-        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "self.<class method>" for example group description.
+        _{name} ^^^^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "self.<class method>" for example group description.
       RUBY
 
       expect_correction <<~RUBY
@@ -16,11 +14,9 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecDotNotSelfDot, :config do
     end
 
     it "corrects #{name} with `self.class_method` and metadata" do
-      left_pad_for_highlight = " " * name.size
-
-      expect_offense <<~RUBY
+      expect_offense <<~RUBY, name: name
         #{name} "self.class_method", foo: true do; end
-        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "self.<class method>" for example group description.
+        _{name} ^^^^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "self.<class method>" for example group description.
       RUBY
 
       expect_correction <<~RUBY
@@ -29,11 +25,9 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecDotNotSelfDot, :config do
     end
 
     it "corrects #{name} with `::class_method`" do
-      left_pad_for_highlight = " " * name.size
-
-      expect_offense <<~RUBY
+      expect_offense <<~RUBY, name: name
         #{name} "::class_method" do; end
-        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "::<class method>" for example group description.
+        _{name} ^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "::<class method>" for example group description.
       RUBY
 
       expect_correction <<~RUBY
@@ -42,11 +36,9 @@ RSpec.describe RuboCop::Cop::Ezcater::RspecDotNotSelfDot, :config do
     end
 
     it "corrects #{name} with `::class_method` and metadata" do
-      left_pad_for_highlight = " " * name.size
-
-      expect_offense <<~RUBY
+      expect_offense <<~RUBY, name: name
         #{name} "::class_method", foo: true do; end
-        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "::<class method>" for example group description.
+        _{name} ^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "::<class method>" for example group description.
       RUBY
 
       expect_correction <<~RUBY

--- a/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_dot_not_self_dot_spec.rb
@@ -1,69 +1,83 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::RspecDotNotSelfDot, :config do
-  subject(:cop) { described_class.new(config) }
-
-  let(:self_dot_msg) { [described_class::SELF_DOT_MSG] }
-  let(:colon_colon_msg) { [described_class::COLON_COLON_MSG] }
-
   described_class::EXAMPLE_GROUP_IDENTIFIERS.each do |name|
     it "corrects #{name} with `self.class_method`" do
-      source = "#{name} \"self.class_method\" do\nend"
-      inspect_source(source)
-      expect(cop.highlights).to match_array(['"self.class_method"'])
-      expect(cop.messages).to match_array(self_dot_msg)
-      expect(autocorrect_source(source)).to eq(source.sub("self.", "."))
+      left_pad_for_highlight = " " * name.size
+
+      expect_offense <<~RUBY
+        #{name} "self.class_method" do; end
+        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "self.<class method>" for example group description.
+      RUBY
+
+      expect_correction <<~RUBY
+        #{name} ".class_method" do; end
+      RUBY
     end
 
     it "corrects #{name} with `self.class_method` and metadata" do
-      source = "#{name} \"self.class_method\", foo: true do\nend"
-      inspect_source(source)
-      expect(cop.highlights).to match_array(['"self.class_method"'])
-      expect(cop.messages).to match_array(self_dot_msg)
-      expect(autocorrect_source(source)).to eq(source.sub("self.", "."))
+      left_pad_for_highlight = " " * name.size
+
+      expect_offense <<~RUBY
+        #{name} "self.class_method", foo: true do; end
+        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "self.<class method>" for example group description.
+      RUBY
+
+      expect_correction <<~RUBY
+        #{name} ".class_method", foo: true do; end
+      RUBY
     end
 
     it "corrects #{name} with `::class_method`" do
-      source = "#{name} \"::class_method\" do\nend"
-      inspect_source(source)
-      expect(cop.highlights).to match_array(['"::class_method"'])
-      expect(cop.messages).to match_array(colon_colon_msg)
-      expect(autocorrect_source(source)).to eq(source.sub("::", "."))
+      left_pad_for_highlight = " " * name.size
+
+      expect_offense <<~RUBY
+        #{name} "::class_method" do; end
+        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "::<class method>" for example group description.
+      RUBY
+
+      expect_correction <<~RUBY
+        #{name} ".class_method" do; end
+      RUBY
     end
 
     it "corrects #{name} with `::class_method` and metadata" do
-      source = "#{name} \"::class_method\", foo: true do\nend"
-      inspect_source(source)
-      expect(cop.highlights).to match_array(['"::class_method"'])
-      expect(cop.messages).to match_array(colon_colon_msg)
-      expect(autocorrect_source(source)).to eq(source.sub("::", "."))
+      left_pad_for_highlight = " " * name.size
+
+      expect_offense <<~RUBY
+        #{name} "::class_method", foo: true do; end
+        #{left_pad_for_highlight} ^^^^^^^^^^^^^^^^ Use ".<class method>" instead of "::<class method>" for example group description.
+      RUBY
+
+      expect_correction <<~RUBY
+        #{name} ".class_method", foo: true do; end
+      RUBY
     end
 
     it "accepts #{name} with `.class_method`" do
-      source = "#{name} \".class_method\" do\nend"
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses <<~RUBY
+        #{name} ".class_method" do; end
+      RUBY
     end
 
     it "accepts #{name} with `self.` not at the start of the string" do
-      source = "#{name} \"something self.class_method\" do\nend"
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses <<~RUBY
+        #{name} "something self.class_method" do; end
+      RUBY
     end
 
     it "accepts #{name} with `::` not at the start of the string" do
-      source = "#{name} \"something ::class_method\" do\nend"
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses <<~RUBY
+        #{name} "something ::class_method" do; end
+      RUBY
     end
   end
 
   described_class::EXAMPLE_IDENTIFIERS.each do |name|
     it "accepts #{name} with `self.class_method`" do
-      source = "#{name} \"self.class_method\" do\nend"
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses <<~RUBY
+        #{name} "self.class_method" do; end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/ezcater/rspec_match_ordered_array_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_match_ordered_array_spec.rb
@@ -1,50 +1,43 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::RspecMatchOrderedArray, :config do
-  subject(:cop) { described_class.new(config) }
-
   it "accepts usage of `match_ordered_array`" do
-    source = "expect(foo).to match_ordered_array([1, 2])"
-
-    inspect_source(source)
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      expect(foo).to match_ordered_array([1, 2])
+    RUBY
   end
 
   it "accepts usage of `match_ordered_array without` method parens" do
-    source = "expect(foo).to match_ordered_array [1, 2]"
-
-    inspect_source(source)
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      expect(foo).to match_ordered_array [1, 2]
+    RUBY
   end
 
   it "accepts usage of `eq` without an array" do
-    source = "expect(foo).to eq(1, 'foo', :baz, nil)"
-
-    inspect_source(source)
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      expect(foo).to eq(1, 'foo', :baz, nil)
+    RUBY
   end
 
   it "corrects when using `eq` matcher for arrays" do
-    source = "expect(foo).to eq([1, 'bar'])"
+    expect_offense <<~RUBY
+      expect(foo).to eq([1, 'bar'])
+                     ^^^^^^^^^^^^^^ Use the `match_ordered_array` matcher from ezcater_matchers gem instead of `eq` when comparing collections
+    RUBY
 
-    inspect_source(source)
-
-    expect(cop.highlights).to match_array("eq([1, 'bar'])")
-    expect(cop.messages).to match_array(described_class::MSG)
-    expect(autocorrect_source(source)).to eq("expect(foo).to match_ordered_array([1, 'bar'])")
+    expect_correction <<~RUBY
+      expect(foo).to match_ordered_array([1, 'bar'])
+    RUBY
   end
 
   it "corrects when using `eq` matcher for arrays without parens" do
-    source = "expect(foo).to eq [nil, :baz]"
+    expect_offense <<~RUBY
+      expect(foo).to eq [nil, :baz]
+                     ^^^^^^^^^^^^^^ Use the `match_ordered_array` matcher from ezcater_matchers gem instead of `eq` when comparing collections
+    RUBY
 
-    inspect_source(source)
-
-    expect(cop.highlights).to match_array("eq [nil, :baz]")
-    expect(cop.messages).to match_array(described_class::MSG)
-    expect(autocorrect_source(source)).to eq("expect(foo).to match_ordered_array [nil, :baz]")
+    expect_correction <<~RUBY
+      expect(foo).to match_ordered_array [nil, :baz]
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_browser_mock_spec.rb
@@ -1,79 +1,89 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
-RSpec.shared_examples_for "a browser class that should be mocked" do |klass|
-  let(:error_message) { format("Ezcater/RspecRequireBrowserMock: #{described_class::MSG}", node_source: klass) }
-
-  context "when the class is '#{klass}'" do
-    it "registers an offense when attempting to directly mock #{klass}" do
-      source = "allow(#{klass}).to receive(:new).with(\"My User Agent\", language: \"en=US,en\")"
-      inspect_source(source)
-      expect(cop.messages).to match_array([error_message])
-      expect(cop.highlights).to match_array([source])
-    end
-
-    it "registers an offense when attempting to directly mock #{klass} when badly formatted" do
-      source = "allow    (   #{klass}   ).to receive(:new).with(\"My User Agent\", language: \"en=US,en\")"
-      inspect_source(source)
-      expect(cop.messages).to match_array([error_message])
-      expect(cop.highlights).to match_array([source])
-    end
-
-    it "accepts usage of #{klass} when nested beneath another constant" do
-      source = "allow(SomeOtherClass::#{klass}).to receive(:new).with(\"My User Agent\", language: \"en=US,en\")"
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
-    end
-  end
-end
-
 RSpec.describe RuboCop::Cop::Ezcater::RspecRequireBrowserMock, :config do
-  subject(:cop) { described_class.new }
-
   it "accepts usage of the mock_ezcater_app helper with no options" do
-    inspect_source("browser = mock_ezcater_app")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      browser = mock_ezcater_app
+    RUBY
   end
 
   it "accepts usage of the mock_ezcater_app helper with options" do
-    inspect_source(
-      "browser = mock_ezcater_app(device: \"iPhone\", version: \"1.2\", language: \"en=US,en\")"
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      browser = mock_ezcater_app(device: "iPhone", version: "1.2", language: "en=US,en")
+    RUBY
   end
 
   it "accepts usage of the mock_chrome_browser helper with no options" do
-    inspect_source("browser = mock_chrome_browser")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      browser = mock_chrome_browser
+    RUBY
   end
 
   it "accepts usage of the mock_chrome_browser helper with options" do
-    inspect_source(
-      "browser = mock_chrome_browser(device: \"iPhone\", version: \"1.2\", language: \"en=US,en\")"
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      browser = mock_chrome_browser(device: "iPhone", version: "1.2", language: "en=US,en")
+    RUBY
   end
 
   it "accepts usage of the mock_custom_browser helper with no options" do
-    inspect_source("browser = mock_custom_browser")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      browser = mock_custom_browser
+    RUBY
   end
 
   it "accepts usage of the mock_custom_browser helper with options" do
-    inspect_source(
-      "browser = mock_custom_browser(usage_agent: \"Custom Agent\", language: \"en=US,en\")"
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      browser = mock_custom_browser(usage_agent: "Custom Agent", language: "en=US,en")
+    RUBY
   end
 
-  it "accepts usage of Browser constant when validating mocked calls" do
-    inspect_source(
-      "expect(Browser).to have_received(:new).with(\"My User Agent\", language: \"en=US,en\")"
-    )
-    expect(cop.offenses).to be_empty
+  context "with Browser class" do
+    it "accepts usage when validating mocked calls" do
+      expect_no_offenses <<~RUBY
+        expect(Browser).to have_received(:new).with("My User Agent", language: "en=US,en")
+      RUBY
+    end
+
+    it "registers offense when attempting to directly mock" do
+      expect_offense <<~RUBY
+        allow(Browser).to receive(:new).with("My User Agent", language: "en=US,en")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the mocks provided by `BrowserHelpers` instead of mocking `Browser`
+      RUBY
+    end
+
+    it "registers offense when directly mocked with bad formatting" do
+      expect_offense <<~RUBY
+        allow    (   Browser   ).to receive(:new).with("My User Agent", language: "en=US,en")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the mocks provided by `BrowserHelpers` instead of mocking `Browser`
+      RUBY
+    end
+
+    it "accepts usage when nested another constant" do
+      expect_no_offenses <<~RUBY
+        allow(SomeOtherClass::Browser).to receive(:new).with("My User Agent", language: "en=US,en")
+      RUBY
+    end
   end
 
-  it_behaves_like "a browser class that should be mocked", "Browser"
-  it_behaves_like "a browser class that should be mocked", "EzBrowser"
+  context "with EzBrowser class" do
+    it "registers offense when attempting to directly mock" do
+      expect_offense <<~RUBY
+        allow(EzBrowser).to receive(:new).with("My User Agent", language: "en=US,en")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the mocks provided by `BrowserHelpers` instead of mocking `EzBrowser`
+      RUBY
+    end
+
+    it "registers offense when directly mocked with bad formatting" do
+      expect_offense <<~RUBY
+        allow    (   EzBrowser   ).to receive(:new).with("My User Agent", language: "en=US,en")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the mocks provided by `BrowserHelpers` instead of mocking `EzBrowser`
+      RUBY
+    end
+
+    it "accepts usage when nested another constant" do
+      expect_no_offenses <<~RUBY
+        allow(SomeOtherClass::EzBrowser).to receive(:new).with("My User Agent", language: "en=US,en")
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
+++ b/spec/rubocop/cop/ezcater/rspec_require_http_status_matcher_spec.rb
@@ -1,28 +1,23 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
-RSpec.describe RuboCop::Cop::Ezcater::RspecRequireHttpStatusMatcher do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::Ezcater::RspecRequireHttpStatusMatcher, :config do
   it "accepts usage of the HTTP status matcher" do
-    inspect_source("expect(response).to have_http_status :bad_request")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      expect(response).to have_http_status :bad_request
+    RUBY
   end
 
   it "registers an offence when attempting to assert directly on the status" do
-    inspect_source("expect(response.status).to eq 400")
-    expect(cop.messages).to match_array(
-      ["Ezcater/RspecRequireHttpStatusMatcher: Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`"]
-    )
+    expect_offense <<~RUBY
+      expect(response.status).to eq 400
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `have_http_status` matcher, like `expect(response).to have_http_status :bad_request`, rather than `expect(response.status).to eq 400`
+    RUBY
   end
 
   it "registers an offence when attempting to assert directly on the code" do
-    inspect_source("expect(response.code).to eq \"400\"")
-    expect(cop.messages).to match_array(
-      ["Ezcater/RspecRequireHttpStatusMatcher: Use the `have_http_status` matcher, like "\
-      "`expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq \"400\"`"]
-    )
+    expect_offense <<~RUBY
+      expect(response.code).to eq "400"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `have_http_status` matcher, like `expect(response).to have_http_status :bad_request`, rather than `expect(response.code).to eq "400"`
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/ruby_timeout_spec.rb
+++ b/spec/rubocop/cop/ezcater/ruby_timeout_spec.rb
@@ -1,59 +1,50 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Ezcater::RubyTimeout do
-  subject(:cop) { described_class.new }
-
-  let(:msgs) { ["Ezcater/RubyTimeout: #{described_class::MSG}"] }
-
+RSpec.describe RuboCop::Cop::Ezcater::RubyTimeout, :config do
   it "detects `Timeout.timeout(n)`" do
-    source = "Timeout.timeout(n) { foo }"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["Timeout.timeout(n)"])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense <<~RUBY
+      Timeout.timeout(n) { foo }
+      ^^^^^^^^^^^^^^^^^^ `Timeout.timeout` is unsafe. Find an alternative to achieve the same goal.  Ex. Use the timeout capabilities of a networking library.  Ex. Iterate and check runtime after each iteration.
+    RUBY
   end
 
   it "detects `::Timeout.timeout(n)`" do
-    source = "::Timeout.timeout(n) { foo }"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["::Timeout.timeout(n)"])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense <<~RUBY
+      ::Timeout.timeout(n) { foo }
+      ^^^^^^^^^^^^^^^^^^^^ `Timeout.timeout` is unsafe. Find an alternative to achieve the same goal.  Ex. Use the timeout capabilities of a networking library.  Ex. Iterate and check runtime after each iteration.
+    RUBY
   end
 
   it "detects `Timeout.timeout(n, a)`" do
-    source = "Timeout.timeout(n, a) { foo }"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["Timeout.timeout(n, a)"])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense <<~RUBY
+      Timeout.timeout(n, a) { foo }
+      ^^^^^^^^^^^^^^^^^^^^^ `Timeout.timeout` is unsafe. Find an alternative to achieve the same goal.  Ex. Use the timeout capabilities of a networking library.  Ex. Iterate and check runtime after each iteration.
+    RUBY
   end
 
   it "detects `Timeout.timeout(n, a, b)`" do
-    source = "Timeout.timeout(n, a, b) { foo }"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array(["Timeout.timeout(n, a, b)"])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense <<~RUBY
+      Timeout.timeout(n, a, b) { foo }
+      ^^^^^^^^^^^^^^^^^^^^^^^^ `Timeout.timeout` is unsafe. Find an alternative to achieve the same goal.  Ex. Use the timeout capabilities of a networking library.  Ex. Iterate and check runtime after each iteration.
+    RUBY
   end
 
   it "detects plain `Timeout.timeout` calls" do
-    source = "Timeout.timeout"
-    inspect_source(source)
-    expect(cop.offenses).not_to be_empty
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
+    expect_offense <<~RUBY
+      Timeout.timeout
+      ^^^^^^^^^^^^^^^ `Timeout.timeout` is unsafe. Find an alternative to achieve the same goal.  Ex. Use the timeout capabilities of a networking library.  Ex. Iterate and check runtime after each iteration.
+    RUBY
   end
 
   it "accepts `Timeout::Error`" do
-    source = "raise Timeout::Error"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      raise Timeout::Error
+    RUBY
   end
 
   it "accepts `AnyClass.timeout`" do
-    source = "AnyClass.timeout"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      AnyClass.timeout
+    RUBY
   end
 end

--- a/spec/rubocop/cop/ezcater/style_dig_spec.rb
+++ b/spec/rubocop/cop/ezcater/style_dig_spec.rb
@@ -1,115 +1,138 @@
-# encoding utf-8
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Ezcater::StyleDig, :config do
-  subject(:cop) { described_class.new(config) }
-
-  let(:ruby_version) { 3.1 }
-  let(:msgs) { [described_class::MSG] }
-
   it "accepts non-nested access" do
-    source = "ary[0]"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      ary[0]
+    RUBY
   end
 
   it "corrects nested access" do
-    source = "hash[one][two]"
-    inspect_source(source)
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("hash.dig(one, two)")
+    expect_offense <<~RUBY
+      hash[one][two]
+      ^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      hash.dig(one, two)
+    RUBY
   end
 
   it "corrects triple-nested access" do
-    source = "hash[one][two][three]"
-    inspect_source(source)
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("hash.dig(one, two, three)")
+    expect_offense <<~RUBY
+      hash[one][two][three]
+      ^^^^^^^^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      hash.dig(one, two, three)
+    RUBY
   end
 
   it "corrects nested access after a method call" do
-    source = "obj.hash[:one][:two]"
-    inspect_source(source)
-    expect(cop.highlights).to match_array([source])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("obj.hash.dig(:one, :two)")
+    expect_offense <<~RUBY
+      obj.hash[:one][:two]
+      ^^^^^^^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      obj.hash.dig(:one, :two)
+    RUBY
   end
 
   it "corrects nested access for a method arg" do
-    source = "call(array[0][1])"
-    inspect_source(source)
-    expect(cop.highlights).to match_array(["array[0][1]"])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("call(array.dig(0, 1))")
+    expect_offense <<~RUBY
+      call(array[0][1])
+           ^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      call(array.dig(0, 1))
+    RUBY
   end
 
   it "corrects when a method is called after nested access" do
-    source = "hash[one][two].foo"
-    inspect_source(source)
-    expect(cop.highlights).to match_array(["hash[one][two]"])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("hash.dig(one, two).foo")
+    expect_offense <<~RUBY
+      hash[one][two].foo
+      ^^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      hash.dig(one, two).foo
+    RUBY
   end
 
   it "accepts nested access on conditional assignment" do
-    source = "foo[bar][baz] ||= 1"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      foo[bar][baz] ||= 1
+    RUBY
   end
 
   it "corrects nested access in the value for conditional assignment" do
-    source = "blah ||= foo[bar][baz]"
-    inspect_source(source)
-    expect(cop.highlights).to match_array(["foo[bar][baz]"])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("blah ||= foo.dig(bar, baz)")
+    expect_offense <<~RUBY
+      blah ||= foo[bar][baz]
+               ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      blah ||= foo.dig(bar, baz)
+    RUBY
   end
 
   it "accepts nested access for increment" do
-    source = "foo[bar][baz] += 1"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      foo[bar][baz] += 1
+    RUBY
   end
 
   it "accepts nested access for assignment" do
-    source = "foo[bar][baz] = 0"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      foo[bar][baz] = 0
+    RUBY
   end
 
   it "corrects nested access with append" do
-    source = "foo[bar][baz] << 1"
-    inspect_source(source)
-    expect(cop.highlights).to match_array(["foo[bar][baz]"])
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("foo.dig(bar, baz) << 1")
+    expect_offense <<~RUBY
+      foo[bar][baz] << 1
+      ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      foo.dig(bar, baz) << 1
+    RUBY
   end
 
   it "accepts nested access that uses an inclusive range" do
-    source = "foo[bar][0..2]"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      foo[bar][0..2]
+    RUBY
   end
 
   it "accepts nested access that uses an exclusive range" do
-    source = "foo[bar][0...2]"
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses <<~RUBY
+      foo[bar][0...2]
+    RUBY
   end
 
   it "corrects nested access before the use of an inclusive range" do
-    source = "foo[bar][baz][0..2]"
-    inspect_source(source)
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("foo.dig(bar, baz)[0..2]")
+    expect_offense <<~RUBY
+      foo[bar][baz][0..2]
+      ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      foo.dig(bar, baz)[0..2]
+    RUBY
   end
 
   it "corrects nested access before the use of an exclusive range" do
-    source = "foo[bar][baz][0...2]"
-    inspect_source(source)
-    expect(cop.messages).to match_array(msgs)
-    expect(autocorrect_source(source)).to eq("foo.dig(bar, baz)[0...2]")
+    expect_offense <<~RUBY
+      foo[bar][baz][0...2]
+      ^^^^^^^^^^^^^ Use `dig` for nested access.
+    RUBY
+
+    expect_correction <<~RUBY
+      foo.dig(bar, baz)[0...2]
+    RUBY
   end
 end


### PR DESCRIPTION
## What did we change?

Refactor following the [V1 Upgrade Guide](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html).

I broke down the upgrade into commits to make it easier to review. The main overview though is:
- Replace custom cops inheriting from `RuboCop::Cop::Cop` to inherit from `RuboCop::Cop::Base`
- Refactor to new `#add_offense` API, which removes `:location` argument
- Refactor tests to now recommended matchers `#expect_offense`, `#expect_no_offenses`, `#expect_correction`, `#expect_no_corrections` (this is the biggest code change). This had to be done because the existing use of `#inspect_source` was tied to `RuboCop::Cop::Cop`.
- Replace `#autocorrect` to new API that yields it from `#add_offense`

NOTE: Based on docs linked, this is all backwards compatible and not a breaking change for clients.

## Why are we doing this?

With [rubocop v1.67](https://github.com/rubocop/rubocop/releases/tag/v1.67.0) it now logs deprecation warnings in console for Cops inheriting from `RuboCop::Cop::Cop` instead of `RuboCop::Cop::Base` (see relevant PR [here](https://github.com/rubocop/rubocop/pull/13253)). While doing this fix I followed the rest of the v1 upgrade steps.

I noticed this when upgrading one app to use latest ezcater_rubocop version, which updated all rubocop dependencies too. Here's the deprecation warnings I was getting when running `rubocop -a`:

```sh
/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/direct_env_check.rb:21: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/feature_flag_active.rb:25: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/feature_flag_name_valid.rb:24: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rails_configuration.rb:6: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rails_env.rb:24: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/ruby_timeout.rb:20: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rails_top_level_sql_execute.rb:17: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/require_custom_error.rb:16: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/require_gql_error_helpers.rb:22: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rspec_match_ordered_array.rb:17: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rspec_require_browser_mock.rb:22: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rspec_require_feature_flag_mock.rb:18: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rspec_require_http_status_matcher.rb:17: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/rspec_dot_not_self_dot.rb:26: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/usr/local/bundle/gems/ezcater_rubocop-7.0.0/lib/rubocop/cop/ezcater/style_dig.rb:19: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```

## How was it tested?
- [x] Specs
- [x] Locally
