### PR TITLE
Disable `BulkChangeTable` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 7.1.1
+
+- Disable `Rails/BulkChangeTable` to avoid conflicts with `strong_migrations`
+
 ## 7.1.0
 - Upgrade rubocop to v1 API (following guide [here](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html)) to stop deprecation warnings in rubocop >=1.67.
 

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -23,6 +23,10 @@ Metrics/BlockLength:
 Rails:
   Enabled: true
 
+# This conflicts with Strong Migrations, which can't check `change_table`
+Rails/ BulkChangeTable:
+  Enabled: false
+
 Rails/FilePath:
   Enabled: false
 

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "7.1.0"
+  VERSION = "7.1.1"
 end


### PR DESCRIPTION
## What/Why did we change?

This config conflicts with [`strong_migrations`](https://github.com/ankane/strong_migrations) due to the usage of `change_table`. `strong_migrations` considers this to be unsafe. 

Rather than try to work around it, we are disabling this cop. More details [here]

[here]: https://github.com/ankane/strong_migrations/issues/204

## How was it tested?
- [ ] Specs
- [x] Locally
