### PR TITLE
Remove stray space in BulkChangeTable  definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 7.1.2
+- 
+- Fix a stray space in `Rails/BulkChangeTable` definition
+
 ## 7.1.1
 
 - Disable `Rails/BulkChangeTable` to avoid conflicts with `strong_migrations`

--- a/conf/rubocop_rails.yml
+++ b/conf/rubocop_rails.yml
@@ -24,7 +24,7 @@ Rails:
   Enabled: true
 
 # This conflicts with Strong Migrations, which can't check `change_table`
-Rails/ BulkChangeTable:
+Rails/BulkChangeTable:
   Enabled: false
 
 Rails/FilePath:

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "7.1.1"
+  VERSION = "7.1.2"
 end


### PR DESCRIPTION
## What did we change?

Via #133, there was a stray whitespace in the config which caused:

```
Error: unrecognized cop or department Rails/ BulkChangeTable found in /usr/local/bundle/gems/ezcater_rubocop-7.1.1/conf/rubocop_rails.yml
Did you mean `Rails/BulkChangeTable`?
```

## How was it tested?
- [ ] Specs
- [x] Locally
