### PR TITLE
Run simple check on Rubocop configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ jobs:
       # Run Rubocop
       - run: bundle exec rubocop
 
+      - run:
+          name: "Validate Rubocop config"
+          command: bin/check_configs.sh
+
       # Run rspec
       - run:
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 7.1.3 (unreleased)
+
+- Update internal CI processes to validate Rubocop config files
+
 ## 7.1.2
-- 
+
 - Fix a stray space in `Rails/BulkChangeTable` definition
 
 ## 7.1.1

--- a/bin/check_configs.sh
+++ b/bin/check_configs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Checks the validity of RuboCop config files in `conf/` directory (excluding the base config).
+
+CONFIGS=(
+  "conf/rubocop_gem.yml"
+  "conf/rubocop_rails.yml"
+)
+
+exit_code=0
+
+for config in "${CONFIGS[@]}"; do
+  if ! output=$(bundle exec rubocop --show-cops -c "$config" 2>&1); then
+    echo "❌ Error in $config"
+    echo "$output"
+    exit_code=1
+  fi
+done
+
+if [[ $exit_code -eq 0 ]]; then
+  echo "✅ All configs are valid"
+fi
+exit $exit_code

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "7.1.2"
+  VERSION = "7.1.3"
 end


### PR DESCRIPTION
## What did we change?
- Add a simple script to validate configs within [`conf/`](https://github.com/ezcater/ezcater_rubocop/tree/main/conf)

## Why are we doing this?
- In #133, I had an invalid stray space but nothing told me about it within the PR and that lead to fun surprises


## Pics (Locally)
<img width="799" alt="Screenshot 2024-12-16 at 11 09 40 AM" src="https://github.com/user-attachments/assets/94bde8a8-1a4f-4112-a5a0-ade8cb1e43b9" />

## Pics (Circle CI)
[Example Link
](https://app.circleci.com/pipelines/github/ezcater/ezcater_rubocop/193/workflows/782acca8-c1c3-4a50-bc3b-a3ed92a98807/jobs/697)
<img width="955" alt="Screenshot 2024-12-16 at 11 23 54 AM" src="https://github.com/user-attachments/assets/da519aca-fba1-486c-a5f3-d666d87f3910" />


## How was it tested?
- [x] Specs
- [x] Locally
