### PR TITLE
Pin maximum versions of `rubocop` and `rubocop-rails`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 8.0.1 (February 20, 2025)
+
+- Pin maximum versions of `rubocop` and `rubocop-rails` to the versions before they moved to the `plugin` architecture in 1.72 and 2.28, respectively
+
 ## 8.0.0
 
 - Add `Ezcater/Migration/BigintForeignKey` Cop, which enforces the use of `bigint` for foreign keys in migrations.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,128 @@
+PATH
+  remote: .
+  specs:
+    ezcater_rubocop (8.0.0)
+      parser (>= 2.6)
+      rubocop (>= 1.16.0, < 1.72.0)
+      rubocop-graphql (>= 0.14.0, < 1.0)
+      rubocop-rails (>= 2.10.1, < 2.28.0)
+      rubocop-rspec (>= 2.22.0, < 2.28.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    ast (2.4.2)
+    base64 (0.2.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
+    diff-lcs (1.6.0)
+    docile (1.4.1)
+    drb (2.2.1)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    json (2.10.1)
+    language_server-protocol (3.17.0.4)
+    logger (1.6.6)
+    method_source (1.1.0)
+    minitest (5.25.4)
+    parallel (1.26.3)
+    parser (3.3.7.1)
+      ast (~> 2.4.1)
+      racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.1)
+    rack (3.1.10)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (1.71.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.38.0)
+      parser (>= 3.3.1.0)
+    rubocop-capybara (2.21.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
+    rubocop-graphql (0.19.0)
+      rubocop (>= 0.87, < 2)
+    rubocop-rails (2.27.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (2.27.1)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+
+PLATFORMS
+  arm64-darwin-24
+
+DEPENDENCIES
+  bundler
+  ezcater_rubocop!
+  pry-byebug
+  rake (~> 13.0)
+  rspec (~> 3.11)
+  rspec_junit_formatter
+  simplecov
+
+BUNDLED WITH
+   2.3.7

--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -52,8 +52,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_runtime_dependency "parser", ">= 2.6"
-  spec.add_runtime_dependency "rubocop", ">= 1.16.0", "< 2.0"
+  spec.add_runtime_dependency "rubocop", ">= 1.16.0", "< 1.72.0"
   spec.add_runtime_dependency "rubocop-graphql", ">= 0.14.0", "< 1.0"
-  spec.add_runtime_dependency "rubocop-rails", ">= 2.10.1", "< 3.0"
+  spec.add_runtime_dependency "rubocop-rails", ">= 2.10.1", "< 2.28.0"
   spec.add_runtime_dependency "rubocop-rspec", ">= 2.22.0", "< 2.28.0"
 end

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "8.0.0"
+  VERSION = "8.1.0"
 end


### PR DESCRIPTION
## What did we change?

Pin maximum versions of `rubocop` and `rubocop-rails`

Also, include `Gemfile.lock` in version control. The recommendation to exclude this is outdated, and tools like Dependabot obviate the CI benefits of this approach that simultaneously make local development harder

## Why are we doing this?

Release `1.72` of `rubocop` begins using the `plugins` architecture, which is how `rubocop-rails` is included moving forward. This is not compatible with how we setup inheriting from this gem in our internal gems, and because this gem neither pins maximum versions, nor includes `Gemfile.lock` in version control, `bundle install` could install incompatible versions of those gems.

The goal here is to make version 8.1 of this gem compatible with the pre-`plugin` configuration for rubocop, and a subsequent major version will be compatible with the newer versions of the gems.

## How was it tested?
- [x] Specs
- [ ] Locally
