### PR TITLE
Set up GitHub Action for trusted publishing to RubyGems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release Gem
+on: workflow_dispatch
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Releasing a New Version
 
-To release a new version, update the version number in `version.rb`, merge your PR to `main`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To release a new version, update the version number in `version.rb`, merge your PR to `main`, and then manually run the "Release Gem" GitHub Action, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 


### PR DESCRIPTION
## What did we change?
Setup a GitHub Action that uses the RubyGems [trusted publishing](https://guides.rubygems.org/trusted-publishing/) feature to  publish the gem without requiring long-lived secrets. A trusted publisher has already been added on the RubyGems side for this gem.

## Why are we doing this?
To [reduce the supply chain risk](https://ezcater.atlassian.net/wiki/spaces/TRUST/pages/5259591681/Mitigating+Supply+Chain+Risk+Centralizing+Ownership+and+Publication+of+ezCater+Ruby+Gems) that comes with multiple people having push access with personal RubyGems accounts. Once we know this works we can remove everyone except the ezCater-controlled RubyGems account from the owners list.

## How was it tested?
- [x] Specs
- [ ] Locally
