### PR TITLE
Release version 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 10.0.0 (August 20, 2025)
+
+- Add `Ezcater/RspecNoResolveClassField` cop, which prevents using the deprecated GraphQL testing interface `resolve_class_field`.
+
 ## 9.0.0 (February 24, 2025)
 
 - Add support for `plugin` architecture in `rubocop >= 1.72.0` and `rubocop-rails >= 2.28.0`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ezcater_rubocop (9.0.0)
+    ezcater_rubocop (10.0.0)
       parser (>= 2.6)
       rubocop (>= 1.72.0, < 2.0)
       rubocop-graphql (>= 0.14.0, < 1.0)

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "9.0.0"
+  VERSION = "10.0.0"
 end


### PR DESCRIPTION
## What did we change?
- Update version to 10.0.0
- Update CHANGELOG with information about the new RspecNoResolveClassField cop

## Why are we doing this?
Because I didn't include the release in the PR with the new cop 😞 

## How was it tested?
- [ ] Specs
- [ ] Locally
