### PR TITLE
fix: update Capybara cop names to Capybara/RSpec namespace

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -244,10 +244,10 @@ Rails/Pick:
 Rails/RedundantForeignKey:
   Enabled: true
 
-Capybara/CurrentPathExpectation:
+Capybara/RSpec/CurrentPathExpectation:
   Enabled: true
 
-Capybara/VisibilityMatcher:
+Capybara/RSpec/VisibilityMatcher:
   Enabled: true
 
 RSpec/Dialect:


### PR DESCRIPTION
## What did we change?

Renamed two obsolete Capybara cop references in `conf/rubocop.yml` to their current `Capybara/RSpec` namespace.

`rubocop-capybara` moved these cops in a recent release:
- `Capybara/CurrentPathExpectation` → `Capybara/RSpec/CurrentPathExpectation`
- `Capybara/VisibilityMatcher` → `Capybara/RSpec/VisibilityMatcher`

The old names now cause RuboCop to exit with code 2 (`obsolete configuration found`) in any gem inheriting this config, breaking CI. Discovered while working on [MX-1383](https://ezcater.atlassian.net/browse/MX-1383) — 7 of the 12 private gem repos are failing lint because they have no committed `Gemfile.lock` and resolve to `ezcater_rubocop 11.0.0` on CI.

Example: https://github.com/ezcater/ezcater_avro/actions/runs/26967088018/job/79572446768?pr=56

## How was it tested?
- [ ] Locally
- [ ] Staging

[skip-jira]

[MX-1383]: https://ezcater.atlassian.net/browse/MX-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ