### PR TITLE
chore(release): 11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This gem is moving onto its own [Semantic Versioning](https://semver.org/) schem
 
 Prior to v1.0.0 this gem was versioned based on the `MAJOR`.`MINOR` version of RuboCop. The first release of the ezcater_rubocop gem was `v0.49.0`.
 
+## 11.0.1 (June 5, 2026)
+
+- Fix obsolete Capybara cop references: rename `Capybara/CurrentPathExpectation` → `Capybara/RSpec/CurrentPathExpectation` and `Capybara/VisibilityMatcher` → `Capybara/RSpec/VisibilityMatcher` to match the current `rubocop-capybara` namespace
+- Bump rack from 3.2.1 to 3.2.6
+- Bump activesupport from 7.2.2.2 to 7.2.3.1
+- Bump json from 2.15.0 to 2.15.2.1
+
 ## 11.0.0 (September 23, 2025)
 
 - Update all gem dependencies to the latest version

--- a/lib/ezcater_rubocop/version.rb
+++ b/lib/ezcater_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzcaterRubocop
-  VERSION = "11.0.0"
+  VERSION = "11.0.1"
 end


### PR DESCRIPTION
## What did we change?

Releases v11.0.1 — patch fix for the Capybara cop namespace rename that was causing CI failures in downstream gems, plus minor dependency bumps merged since v11.0.0.

## Changelog

### 11.0.1 (June 5, 2026)

- Fix obsolete Capybara cop references: rename `Capybara/CurrentPathExpectation` → `Capybara/RSpec/CurrentPathExpectation` and `Capybara/VisibilityMatcher` → `Capybara/RSpec/VisibilityMatcher` to match the current `rubocop-capybara` namespace
- Bump rack from 3.2.1 to 3.2.6
- Bump activesupport from 7.2.2.2 to 7.2.3.1
- Bump json from 2.15.0 to 2.15.2.1

## How was it tested?
- [ ] Locally
- [ ] Staging

[skip-jira]