### PR TITLE
chore: replace manual release workflow with release-please

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,22 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # v5.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
 
+    permissions:
+      id-token: write # required for rubygems trusted publishing
+
     steps:
       - name: Check out the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -37,10 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-
-    permissions:
-      id-token: write # required for trusted publishing
-      contents: write # required for rake release to push the tag
 
     steps:
       - name: Check out the code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,55 @@
-name: Release Gem
-on: workflow_dispatch
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
-  push:
-    name: Push gem to RubyGems.org
+  release-please:
+    name: Release Please
     runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
-      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+    outputs:
+      release_created: ${{ steps.run-release-please.outputs.release_created }}
 
     steps:
-      # Set up
-      - uses: actions/checkout@v4
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.EZCATER_RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.EZCATER_RELEASE_PLEASE_PRIVATE_KEY }}
+
+      - name: Run Release Please
+        id: run-release-please
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release-type: ruby
+
+  publish-to-rubygems:
+    name: Publish to RubyGems
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+
+    permissions:
+      id-token: write # required for trusted publishing
+      contents: write # required for rake release to push the tag
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           bundler-cache: true
           ruby-version: ruby
 
-      # Release
       - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Releasing a New Version
 
-To release a new version, update the version number in `version.rb`, merge your PR to `main`, and then manually run the "Release Gem" GitHub Action, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+Releases are automated via [release-please](https://github.com/googleapis/release-please-action). When commits following the [Conventional Commits](https://www.conventionalcommits.org/) format are merged to `main`, release-please opens (or updates) a release PR that bumps `version.rb` and updates `CHANGELOG.md` automatically. Merging that PR triggers the `publish-to-rubygems` job, which tags the release and pushes the `.gem` file to [rubygems.org](https://rubygems.org).
+
+You do not need to manually edit `version.rb` or `CHANGELOG.md`. Use the correct commit prefix to drive the version bump:
+
+- `fix:` → patch bump
+- `feat:` → minor bump
+- `feat!:` or `BREAKING CHANGE:` in the body → major bump
 
 ## Contributing
 
@@ -131,30 +137,23 @@ necessary for consistency.
 In addition, you need to:
 
 1. Add the cop to the "Custom Cops" section of this README
-2. Bump the version.
-3. Add a CHANGELOG entry.
+2. Use a conventional commit prefix (`feat:` for a non-breaking new cop, `feat!:` for a breaking one) so release-please bumps the version and updates the CHANGELOG automatically.
 
 
 ### Version Bumps & Changelog Entries
 
-The version for this gem follows [Semantic Versioning]:
+Version bumps and CHANGELOG entries are managed automatically by release-please based on [Conventional Commits]. Use the correct prefix on your PR title (squash-and-merge is required):
 
-1. Bump the MAJOR version for breaking changes. Example: new cop,
-   enabled by default and which cannot be safely autofixed.
+| Commit prefix | Version bump | Example |
+|---|---|---|
+| `fix:` | Patch | `fix: correct typo in cop message` |
+| `feat:` | Minor | `feat: add StyleDig cop` |
+| `feat!:` or `BREAKING CHANGE:` in body | Major | `feat!: enable StyleDig by default` |
+| `chore:`, `docs:`, `ci:` | None | `chore: update CI config` |
 
-2. Bump the MINOR version for new functionality which will not disrupt
-   projects which depend on this gem. Example: new cop, not enabled by
-   default or which can safely be autofixed.
+[Conventional Commits]: https://www.conventionalcommits.org/
 
-3. Bump the PATCH version for backwards compatible bugfixes.
-
-[Semantic Versioning]: https://semver.org/
-
-The version does not need to be bumped and the changelog does not need
-to be updated for chores which do not affect users of this
-gem. Example: updating CI. Omitting these details helps keep the
-signal-to-noise ratio high for people upgrading the gem as these types
-of changes will not affect them.
+`chore:` commits do not trigger a release. This keeps the CHANGELOG focused on changes that affect users of the gem.
 
 ## License
 


### PR DESCRIPTION
## What did we change?

Replaces the broken `workflow_dispatch` + `rubygems/release-gem` workflow with an automated release-please flow, matching the pattern used across ezCater's private gem repos (MX-1383). Also adds PR title linting and updates the README to reflect the new release process.

**Why the old workflow was broken:** The `rubygems/release-gem` action relies on OIDC trusted publishing being configured on RubyGems.org for this specific repo/workflow. That setup was incomplete, causing the workflow to fail at the file-validation stage before any steps ran.

## Changes

### `.github/workflows/release.yml`
- Runs on `push` to `main` and `workflow_dispatch`
- `release-please` job manages the release PR using the `EZCATER_RELEASE_PLEASE_APP_ID` / `EZCATER_RELEASE_PLEASE_PRIVATE_KEY` GitHub App token (so CI runs on the release PR — fixes the long-standing issue where `GITHUB_TOKEN` suppresses downstream workflows)
- `publish-to-rubygems` job triggers on `release_created` via `rubygems/release-gem` trusted publishing, now properly gated on release-please output
- `issues: write` added to global permissions (required by release-please v4 for PR labeling)
- `id-token: write` scoped to `publish-to-rubygems` job only (required for trusted publishing)

### `.github/workflows/lint-pr.yml` (new)
- Validates PR titles against [Conventional Commits](https://www.conventionalcommits.org/) using `amannn/action-semantic-pull-request`
- Matches the pattern used in other ezCater gem repos
- Uses `pull_request_target` so it works correctly for fork PRs on this public repo

### `README.md`
- **Releasing a New Version** — updated to describe the automated release-please flow; removes instructions to manually edit `version.rb` and run the GitHub Action
- **Adding New Cops** — replaced manual "bump the version / add a CHANGELOG entry" steps with conventional commit prefix guidance
- **Version Bumps & Changelog Entries** — replaced manual instructions with a table mapping commit prefixes to version bumps

## Notes for DevEx

The `publish-to-rubygems` job still uses `rubygems/release-gem@v1` trusted publishing. The OIDC trusted publishing configuration on RubyGems.org needs to be verified/fixed for this to work end-to-end. See the [RubyGems trusted publishing docs](https://guides.rubygems.org/trusted-publishing/) for setup.

Part of [MX-1383](https://ezcater.atlassian.net/browse/MX-1383).

## How was it tested?
- [ ] Locally
- [ ] Staging

[MX-1383]: https://ezcater.atlassian.net/browse/MX-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ