### PR TITLE
ci: pin rubygems/release-gem action to SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@f0d7faff26625599a847d40d9fa28ace24c2aacc # v1


### PR DESCRIPTION
## What did we change?

Pin `rubygems/release-gem@v1` to its full commit SHA (`f0d7faff26625599a847d40d9fa28ace24c2aacc`) in `.github/workflows/release.yml`.

## Why are we doing this?

Floating version tags (like `@v1`) can be silently moved to point at a different commit, creating a supply chain attack vector. Pinning to a full SHA ensures the exact code being run in CI is immutable and auditable.

This is the only remaining unpinned action after PR #160 was merged — all other actions across all four workflows are already SHA-pinned.

## How was it tested?
- [ ] Specs
- [ ] Locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)