### PR TITLE
docs: deprecate ezcater_rubocop in favor of linter gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+> [!IMPORTANT]
+> ## ⚠️ This gem is deprecated and this repository is archived
+>
+> `ezcater_rubocop` has been replaced by **`linter`** (repository:
+> [`ezcater/linter-ruby`](https://github.com/ezcater/linter-ruby)), a rewrite
+> built on composable lint profiles. No further releases of `ezcater_rubocop`
+> will be published, and this repository is now read-only.
+>
+> **For ezCater engineers:** migrate to the `linter` gem. See the
+> [`linter-ruby` README](https://github.com/ezcater/linter-ruby) for setup.
+>
+> **For external / public consumers:** the replacement `linter` gem is
+> **internal to ezCater and not publicly available**. We recommend dropping the
+> `ezcater_rubocop` development dependency and vendoring your own RuboCop
+> configuration (copy whichever rules you rely on from this repo's `conf/`
+> directory into a local `.rubocop.yml`).
+>
+> The content below is preserved for historical reference only.
+
+---
+
 # ezcater_rubocop [![CircleCI](https://circleci.com/gh/ezcater/ezcater_rubocop/tree/main.svg?style=svg)](https://circleci.com/gh/ezcater/ezcater_rubocop/tree/main)
 
 ezCater custom cops and shared RuboCop configuration.


### PR DESCRIPTION
## What did we change?
Added a deprecation / forwarding notice to the top of the README. `ezcater_rubocop` is superseded by the `linter` gem ([ezcater/linter-ruby](https://github.com/ezcater/linter-ruby)). The notice directs internal consumers to `linter` and tells external/public consumers to vendor their own RuboCop config (since `linter` is internal-only).

## Why are we doing this?
Part of retiring the public `ezcater_rubocop` repo now that internal consumers have migrated. This forwarding notice must land before the repo is archived (read-only).

Jira: https://ezcater.atlassian.net/browse/MX-1412

## How was it tested?
- [ ] Specs
- [x] Locally (README-only change; rendered notice reviewed)
