### PR TITLE
fix: add deprecation post-install message for the final release

### DIFF
--- a/ezcater_rubocop.gemspec
+++ b/ezcater_rubocop.gemspec
@@ -15,6 +15,16 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ezcater/ezcater_rubocop"
   spec.license       = "MIT"
 
+  spec.post_install_message = <<~MSG
+    NOTE: ezcater_rubocop is DEPRECATED and its repository is archived.
+    This is the final release; no further updates will be published.
+
+    It has been replaced by the `linter` gem:
+      - ezCater engineers: migrate to `linter` (https://github.com/ezcater/linter-ruby).
+      - External users: `linter` is internal to ezCater and not public; drop this
+        dependency and vendor your own RuboCop configuration.
+  MSG
+
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
## What did we change?
Added a `post_install_message` to the gemspec announcing that **`ezcater_rubocop` is deprecated** and pointing users to the replacement `linter` gem. This is meant to ship in the **final release** before the repo is archived ([MX-1412](https://ezcater.atlassian.net/browse/MX-1412)).

The message (dual-audience, mirroring the README notice):
```
NOTE: ezcater_rubocop is DEPRECATED and its repository is archived.
This is the final release; no further updates will be published.

It has been replaced by the `linter` gem:
  - ezCater engineers: migrate to `linter` (https://github.com/ezcater/linter-ruby).
  - External users: `linter` is internal to ezCater and not public; drop this
    dependency and vendor your own RuboCop configuration.
```

## Why are we doing this?
Final step of the `ezcater_rubocop` → `linter` migration (MX-1411). A post-install message gives anyone still installing the gem (incl. `bundle install`, which prints post-install messages) a clear deprecation + migration pointer. See [MX-1412](https://ezcater.atlassian.net/browse/MX-1412).

## How was it tested?
- [x] `gem build ezcater_rubocop.gemspec` succeeds; confirmed the `post_install_message` is embedded in the built spec.

---
Release flow: this repo uses **release-please** + trusted-publish to RubyGems. Merging this `feat:` to `main` will open a release PR (minor → `11.1.0`); merging that publishes the final release with the deprecation message. **After that, archive the repo** (the README already carries the forwarding notice). Kept as **draft** — monolith-experience-owned, Core Platform to merge/sequence the release + archive.


[MX-1412]: https://ezcater.atlassian.net/browse/MX-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MX-1412]: https://ezcater.atlassian.net/browse/MX-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ